### PR TITLE
Добавил отступ у body только для .navbar-fixed

### DIFF
--- a/backend/design/css/okay.css
+++ b/backend/design/css/okay.css
@@ -54,7 +54,11 @@ body {
     max-width: 100%;
     min-height: 100%;
     /*overflow: hidden;*/
-    padding: 55px 0 0 !important;
+    margin: 0;
+    padding: 0;
+}
+body.navbar-fixed {
+    padding-top: 55px !important;
 }
 .design_block_parent_element {
     position: relative;


### PR DESCRIPTION
### Что PR делает?
Добавил отступ у body только для `.navbar-fixed` иначе ненужный отступ и скролл в форме входа есть:

![login_scroll](https://user-images.githubusercontent.com/12523676/112470175-6894ad00-8d7b-11eb-9912-593ea98d1621.png)

p.s. По-моему, и **в установщике отступ тоже есть ненужный.**