### PR TITLE
add notify extenders for disabling Emails sending

### DIFF
--- a/Okay/Core/Notify.php
+++ b/Okay/Core/Notify.php
@@ -360,6 +360,11 @@ class Notify
         if (!($comment = $commentsEntity->get(intval($commentId)))) {
             return false;
         }
+
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailCommentAdmin($comment)) {
+            return $this->notifyHelper->notSendEmailCommentAdmin($comment);
+        }
         
         if ($comment->type == 'product') {
             $comment->product = $productsEntity->get(intval($comment->object_id));
@@ -374,6 +379,8 @@ class Notify
         // Перевод админки
         $this->backendTranslations->initTranslations($this->settings->get('email_lang'));
         $this->design->assign('btr', $this->backendTranslations);
+
+        $this->notifyHelper->finalEmailCommentAdmin($comment);
         
         // Отправляем письмо
         $emailTemplate = $this->design->fetch($this->rootDir.'backend/design/html/email/email_comment_admin.tpl');
@@ -398,11 +405,19 @@ class Notify
         if (!($callback = $callbacksEntity->get(intval($callbackId)))) {
             return false;
         }
+
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailCallbackAdmin($callback)) {
+            return $this->notifyHelper->notSendEmailCallbackAdmin($callback);
+        }
+        
         $this->design->assign('callback', $callback);
 
         // Перевод админки
         $this->backendTranslations->initTranslations($this->settings->get('email_lang'));
         $this->design->assign('btr', $this->backendTranslations);
+
+        $this->notifyHelper->finalEmailCallbackAdmin($callback);
         
         // Отправляем письмо
         $emailTemplate = $this->design->fetch($this->rootDir.'backend/design/html/email/email_callback_admin.tpl');
@@ -436,6 +451,11 @@ class Notify
             return false;
         }
 
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailCommentAnswerToUser($comment)) {
+            return $this->notifyHelper->notSendEmailCommentAnswerToUser($comment);
+        }
+
         $templateDir = $this->design->getTemplatesDir();
         $compiledDir = $this->design->getCompiledDir();
         $this->design->setTemplatesDir('design/'.$this->frontTemplateConfig->getTheme().'/html');
@@ -465,6 +485,8 @@ class Notify
 
         $this->design->assign('comment', $comment);
         $this->design->assign('parent_comment', $parentComment);
+
+        $this->notifyHelper->finalEmailCommentAnswerToUser($comment);
 
         // Отправляем письмо
         $emailTemplate = $this->design->fetch($this->rootDir.'design/'.$this->frontTemplateConfig->getTheme().'/html/email/email_comment_answer_to_user.tpl');
@@ -500,6 +522,11 @@ class Notify
             return false;
         }
 
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailPasswordRemind($user)) {
+            return $this->notifyHelper->notSendEmailPasswordRemind($user, $code);
+        }
+
         $currentLangId = $this->languages->getLangId();
 
         $this->settings->initSettings();
@@ -508,6 +535,8 @@ class Notify
         
         $this->design->assign('user', $user);
         $this->design->assign('code', $code);
+
+        $this->notifyHelper->finalEmailPasswordRemind($user, $code);
         
         // Отправляем письмо
         $email_template = $this->design->fetch($this->rootDir.'design/'.$this->frontTemplateConfig->getTheme().'/html/email/email_password_remind.tpl');
@@ -531,12 +560,19 @@ class Notify
         if (!($feedback = $feedbackEntity->get(intval($feedbackId)))) {
             return false;
         }
+
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailFeedbackAdmin($feedback)) {
+            return $this->notifyHelper->notSendEmailFeedbackAdmin($feedback);
+        }
         
         $this->design->assign('feedback', $feedback);
 
         // Перевод админки
         $this->backendTranslations->initTranslations($this->settings->get('email_lang'));
         $this->design->assign('btr', $this->backendTranslations);
+
+        $this->notifyHelper->finalEmailFeedbackAdmin($feedback);
         
         // Отправляем письмо
         $emailTemplate = $this->design->fetch($this->rootDir.'backend/design/html/email/email_feedback_admin.tpl');
@@ -555,7 +591,7 @@ class Notify
     }
 
     /*Отправка емейла с ответом на заявку с формы обратной связи клиенту*/
-    public function emailFeedbackAnswerFoUser($comment_id,$text)
+    public function emailFeedbackAnswerFoUser($comment_id, $text)
     {
 
         /** @var FeedbacksEntity $feedbackEntity */
@@ -563,6 +599,11 @@ class Notify
 
         if(!($feedback = $feedbackEntity->get(intval($comment_id)))) {
             return false;
+        }
+
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailFeedbackAnswerForUser($feedback)) {
+            return $this->notifyHelper->notSendEmailFeedbackAnswerForUser($feedback, $text);
         }
 
         $templateDir = $this->design->getTemplatesDir();
@@ -583,6 +624,8 @@ class Notify
 
         $this->design->assign('feedback', $feedback);
         $this->design->assign('text', $text);
+
+        $this->notifyHelper->finalEmailFeedbackAnswerForUser($feedback, $text);
 
         // Отправляем письмо
         $email_template = $this->design->fetch($this->rootDir.'design/'.$this->frontTemplateConfig->getTheme().'/html/email/email_feedback_answer_to_user.tpl');
@@ -609,12 +652,20 @@ class Notify
             return false;
         }
 
+        // если не нужно отправлять письмо, вызываем хелпер, может нужно сделать какую-то альтернативу
+        if (!$this->notifyHelper->needSendEmailPasswordRecoveryAdmin($email)) {
+            return $this->notifyHelper->notSendEmailPasswordRecoveryAdmin($email, $code);
+        }
+
         // Перевод админки
         $this->backendTranslations->initTranslations($this->settings->get('email_lang'));
         $this->design->assign('btr', $this->backendTranslations);
         
         $this->design->assign('code',$code);
         $this->design->assign('recovery_url', Request::getRootUrl() . '/backend/index.php?controller=AuthAdmin&code='.$code);
+
+        $this->notifyHelper->finalEmailPasswordRecoveryAdmin($email, $code);
+        
         $email_template = $this->design->fetch($this->rootDir.'backend/design/html/email/email_admin_recovery.tpl');
         $subject = $this->design->getVar('subject');
         $this->email($email, $subject, $email_template, $this->settings->get('notify_from_name'));

--- a/Okay/Helpers/NotifyHelper.php
+++ b/Okay/Helpers/NotifyHelper.php
@@ -29,17 +29,160 @@ class NotifyHelper
     }
 
     /**
+     * Метод вызывается непосредственно перед отправкой письма админу о новом комментарии. Письмо будет отправлено
+     *
+     * @param $comment
+     */
+    public function finalEmailCommentAdmin($comment)
+    {
+        ExtenderFacade::execute(__METHOD__, $comment, func_get_args());
+    }
+    
+    /**
+     * Метод вызывается непосредственно перед отправкой письма о заявке на обратный завок. Письмо будет отправлено
+     *
+     * @param $callback
+     */
+    public function finalEmailCallbackAdmin($callback)
+    {
+        ExtenderFacade::execute(__METHOD__, $callback, func_get_args());
+    }
+    
+    /**
+     * Метод вызывается непосредственно перед отправкой письма пользователю об ответе на комментарий. Письмо будет отправлено
+     *
+     * @param $comment
+     */
+    public function finalEmailCommentAnswerToUser($comment)
+    {
+        ExtenderFacade::execute(__METHOD__, $comment, func_get_args());
+    }
+    
+    /**
+     * Метод вызывается непосредственно перед отправкой письма пользователю о сбросе пароля. Письмо будет отправлено
+     *
+     * @param $user
+     * @param $code
+     */
+    public function finalEmailPasswordRemind($user, $code)
+    {
+        ExtenderFacade::execute(__METHOD__, $user, func_get_args());
+    }
+    
+    /**
+     * Метод вызывается непосредственно перед отправкой письма пользователю с ответом на заявку в обратную связь. Письмо будет отправлено
+     *
+     * @param $feedback
+     * @param $text
+     */
+    public function finalEmailFeedbackAnswerForUser($feedback, $text)
+    {
+        ExtenderFacade::execute(__METHOD__, $feedback, func_get_args());
+    }
+    
+    /**
+     * Метод вызывается непосредственно перед отправкой письма админу о заявке в обратную связь . Письмо будет отправлено
+     *
+     * @param $feedback
+     */
+    public function finalEmailFeedbackAdmin($feedback)
+    {
+        ExtenderFacade::execute(__METHOD__, $feedback, func_get_args());
+    }
+    
+    /**
+     * Метод вызывается непосредственно перед отправкой письма о сбросе пароля администратора. Письмо будет отправлено
+     *
+     * @param $email
+     * @param $code
+     */
+    public function finalEmailPasswordRecoveryAdmin($email, $code)
+    {
+        ExtenderFacade::execute(__METHOD__, $email, func_get_args());
+    }
+
+    /**
      * @param $order
-     * @return false|mixed|void|null
+     * @return object
      */
     public function notSendEmailOrderAdmin($order)
     {
         return ExtenderFacade::execute(__METHOD__, $order, func_get_args());
     }
-    
+
+    /**
+     * @param $order
+     * @return object
+     */
     public function notSendEmailOrderUser($order)
     {
         return ExtenderFacade::execute(__METHOD__, $order, func_get_args());
+    }
+
+    /**
+     * @param $comment
+     * @return object
+     */
+    public function notSendEmailCommentAdmin($comment)
+    {
+        return ExtenderFacade::execute(__METHOD__, $comment, func_get_args());
+    }
+
+    /**
+     * @param $callback
+     * @return object
+     */
+    public function notSendEmailCallbackAdmin($callback)
+    {
+        return ExtenderFacade::execute(__METHOD__, $callback, func_get_args());
+    }
+
+    /**
+     * @param $comment
+     * @return object
+     */
+    public function notSendEmailCommentAnswerToUser($comment)
+    {
+        return ExtenderFacade::execute(__METHOD__, $comment, func_get_args());
+    }
+
+    /**
+     * @param $user
+     * @param $code
+     * @return object
+     */
+    public function notSendEmailPasswordRemind($user, $code)
+    {
+        return ExtenderFacade::execute(__METHOD__, $user, func_get_args());
+    }
+    
+    /**
+     * @param $feedback
+     * @param $text
+     * @return object
+     */
+    public function notSendEmailFeedbackAnswerForUser($feedback, $text)
+    {
+        return ExtenderFacade::execute(__METHOD__, $feedback, func_get_args());
+    }
+
+    /**
+     * @param $feedback
+     * @return object
+     */
+    public function notSendEmailFeedbackAdmin($feedback)
+    {
+        return ExtenderFacade::execute(__METHOD__, $feedback, func_get_args());
+    }
+    
+    /**
+     * @param $email
+     * @param $code
+     * @return object
+     */
+    public function notSendEmailPasswordRecoveryAdmin($email, $code)
+    {
+        return ExtenderFacade::execute(__METHOD__, $email, func_get_args());
     }
 
     /**
@@ -62,6 +205,90 @@ class NotifyHelper
      * @return bool
      */
     public function needSendEmailOrderAdmin($order)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    }
+
+    /**
+     * Нужно ли отправлять письмо админу о комментарии (может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $comment
+     * @return bool
+     */
+    public function needSendEmailCommentAdmin($comment)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    }
+    
+    /**
+     * Нужно ли отправлять письмо админу о заявке на обратный звонок(может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $callback
+     * @return bool
+     */
+    public function needSendEmailCallbackAdmin($callback)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    }
+    
+    /**
+     * Нужно ли отправлять письмо клиенту о ответе на комментарий(может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $comment
+     * @return bool
+     */
+    public function needSendEmailCommentAnswerToUser($comment)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    }
+    
+    /**
+     * Нужно ли отправлять письмо клиенту о сбросе пароля(может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $user
+     * @return bool
+     */
+    public function needSendEmailPasswordRemind($user)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    }
+    
+    /**
+     * Нужно ли отправлять письмо клиенту письмо с ответом на заявку в обратную связь (может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $feedback
+     * @return bool
+     */
+    public function needSendEmailFeedbackAnswerForUser($feedback)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    }
+    
+    /**
+     * Нужно ли отправлять письмо админу из формы обратной связи (может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $feedback
+     * @return bool
+     */
+    public function needSendEmailFeedbackAdmin($feedback)
+    {
+        return ExtenderFacade::execute(__METHOD__, true, func_get_args());
+    } 
+    
+    /**
+     * Нужно ли отправлять письмо админу из формы обратной связи (может понадобится если модуль отправляет свое письмо,
+     * а это нужно отменить)
+     *
+     * @param $email
+     * @return bool
+     */
+    public function needSendEmailPasswordRecoveryAdmin($email)
     {
         return ExtenderFacade::execute(__METHOD__, true, func_get_args());
     }


### PR DESCRIPTION
### Что PR делает?

Добавлены экстендеры во все функции отправки email  в ядре

### Зачем PR нужен?

Добавляет возможность отменять/переопределять отправку письма,
также расширять метод непосредственно перед отправкой 
