### PR TITLE
move Extenders to start method in delete methods

### DIFF
--- a/backend/Helpers/BackendBlogHelper.php
+++ b/backend/Helpers/BackendBlogHelper.php
@@ -93,11 +93,11 @@ class BackendBlogHelper
 
     public function delete($ids)
     {
+        ExtenderFacade::execute(__METHOD__, null, func_get_args());
+       
         if (is_array($ids)) {
             $this->blogEntity->delete($ids);
         }
-
-        ExtenderFacade::execute(__METHOD__, null, func_get_args());
     }
 
     public function buildPostsFilter()

--- a/backend/Helpers/BackendBrandsHelper.php
+++ b/backend/Helpers/BackendBrandsHelper.php
@@ -167,8 +167,8 @@ class BackendBrandsHelper
 
     public function delete($ids)
     {
-        $this->brandsEntity->delete($ids);
         ExtenderFacade::execute(__METHOD__, null, func_get_args());
+        $this->brandsEntity->delete($ids);
     }
 
     public function moveToPage($ids, $targetPage, $filter)

--- a/backend/Helpers/BackendCategoriesHelper.php
+++ b/backend/Helpers/BackendCategoriesHelper.php
@@ -71,8 +71,8 @@ class BackendCategoriesHelper
 
     public function delete($ids)
     {
-        $this->categoriesEntity->delete($ids);
         ExtenderFacade::execute(__METHOD__, null, func_get_args());
+        $this->categoriesEntity->delete($ids);
     }
 
     public function countAllCategories()

--- a/backend/Helpers/BackendOrdersHelper.php
+++ b/backend/Helpers/BackendOrdersHelper.php
@@ -259,12 +259,13 @@ class BackendOrdersHelper
     
     public function deletePurchases($order, array $postedPurchasesIds)
     {
+        ExtenderFacade::execute(__METHOD__, null, func_get_args());
+        
         foreach ($this->purchasesEntity->find(['order_id' => $order->id]) as $p) {
             if (!in_array($p->id, $postedPurchasesIds)) {
                 $this->purchasesEntity->delete($p->id);
             }
         }
-        ExtenderFacade::execute(__METHOD__, null, func_get_args());
     }
     
     public function updateOrderStatus($order, $newStatusId)
@@ -473,8 +474,8 @@ class BackendOrdersHelper
 
     public function delete($ids)
     {
-        $this->ordersEntity->delete($ids);
         ExtenderFacade::execute(__METHOD__, null, func_get_args());
+        $this->ordersEntity->delete($ids);
     }
 
     public function changeStatus($ids)

--- a/backend/Helpers/BackendProductsHelper.php
+++ b/backend/Helpers/BackendProductsHelper.php
@@ -639,8 +639,8 @@ class BackendProductsHelper
 
     public function delete($ids)
     {
-        $this->productsEntity->delete($ids);
         ExtenderFacade::execute(__METHOD__, null, func_get_args());
+        $this->productsEntity->delete($ids);
     }
 
 }


### PR DESCRIPTION
### Что PR делает?

Перенесены некоторые Экстендеры в начало методов удаления

### Зачем PR нужен?

Появляется возможность почистить необходимые связи удаляемых сущностей. до которых нельзя добраться после удаления

