### PR TITLE
FIX novaposhta delivery cost adding to order delivery price, even if …

### DIFF
--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Extenders/FrontExtender.php
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Extenders/FrontExtender.php
@@ -124,7 +124,7 @@ class FrontExtender implements ExtensionInterface
      */
     public function setCartDeliveryPrice($result, $delivery, $order)
     {
-        if ($this->request->post('is_novaposhta_delivery', 'boolean')) {
+        if ($this->request->post('is_novaposhta_delivery', 'boolean') && $delivery->paid) {
             $result['delivery_price'] = $this->request->post('novaposhta_delivery_price');
         }
         return $result;


### PR DESCRIPTION
### Что PR делает?

В модуль новой почты лобавил проверку на "Бесплатную доставку".

### Зачем PR нужен?

Новая почта добавляла стоимость доставки, даже если способ доставки был бесплатный.