### PR TITLE
Added extension in updateItem method of Cart.php

### DIFF
--- a/Okay/Core/Cart.php
+++ b/Okay/Core/Cart.php
@@ -234,6 +234,8 @@ class Cart
         } else {
             $this->addItem($variantId, $amount);
         }
+
+        ExtenderFacade::execute(__METHOD__, $this, func_get_args());
     }
 
     /**


### PR DESCRIPTION
### Что PR делает?

Добавляет extension в метод updateItem класса Cart.php

### Зачем PR нужен?

Фикс бага, extension должен там быть