### PR TITLE
Casting to type 'string' in MetadataHelpers

### DIFF
--- a/Okay/Helpers/MetadataHelpers/AllProductsMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/AllProductsMetadataHelper.php
@@ -27,7 +27,7 @@ class AllProductsMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         if ($keyword = $this->design->getVar('keyword')) {
             /** @var FrontTranslations $translations */
@@ -43,7 +43,7 @@ class AllProductsMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         if ($keyword = $this->design->getVar('keyword')) {
             /** @var FrontTranslations $translations */
@@ -59,7 +59,7 @@ class AllProductsMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         if ($keyword = $this->design->getVar('keyword')) {
             /** @var FrontTranslations $translations */
@@ -84,7 +84,7 @@ class AllProductsMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         if ($keyword = $this->design->getVar('keyword')) {
             /** @var FrontTranslations $translations */
@@ -100,7 +100,7 @@ class AllProductsMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         if ($keyword = $this->design->getVar('keyword')) {
             /** @var FrontTranslations $translations */

--- a/Okay/Helpers/MetadataHelpers/AuthorMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/AuthorMetadataHelper.php
@@ -13,14 +13,14 @@ class AuthorMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         $author = $this->design->getVar('author');
 
         if ($pageH1 = parent::getH1Template()) {
             $h1 = $pageH1;
         } else {
-            $h1 = $author->name;
+            $h1 = (string)$author->name;
         }
 
         return ExtenderFacade::execute(__METHOD__, $h1, func_get_args());
@@ -29,7 +29,7 @@ class AuthorMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         $author = $this->design->getVar('author');
         $isAllPages = $this->design->getVar('is_all_pages');
@@ -40,7 +40,7 @@ class AuthorMetadataHelper extends CommonMetadataHelper
         } elseif ($pageDescription = parent::getDescriptionTemplate()) {
             $description = $pageDescription;
         } else {
-            $description = $author->description;
+            $description = (string)$author->description;
         }
 
         return ExtenderFacade::execute(__METHOD__, $description, func_get_args());
@@ -49,7 +49,7 @@ class AuthorMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         $author = $this->design->getVar('author');
         $isAllPages = $this->design->getVar('is_all_pages');
@@ -58,7 +58,7 @@ class AuthorMetadataHelper extends CommonMetadataHelper
         if ($pageTitle = parent::getMetaTitleTemplate()) {
             $metaTitle = $pageTitle;
         } else {
-            $metaTitle = $author->meta_title;
+            $metaTitle = (string)$author->meta_title;
         }
 
         // Добавим номер страницы к тайтлу
@@ -74,14 +74,14 @@ class AuthorMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         $author = $this->design->getVar('author');
 
         if ($pageKeywords = parent::getMetaKeywordsTemplate()) {
             $metaKeywords = $pageKeywords;
         } else {
-            $metaKeywords = $author->meta_keywords;
+            $metaKeywords = (string)$author->meta_keywords;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaKeywords, func_get_args());
@@ -90,14 +90,14 @@ class AuthorMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         $author = $this->design->getVar('author');
 
         if ($pageMetaDescription = parent::getMetaDescriptionTemplate()) {
             $metaDescription = $pageMetaDescription;
         } else {
-            $metaDescription = $author->meta_description;
+            $metaDescription = (string)$author->meta_description;
         }
         
         return ExtenderFacade::execute(__METHOD__, $metaDescription, func_get_args());
@@ -106,7 +106,7 @@ class AuthorMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    protected function getParts() : array
+    protected function getParts(): array
     {
         if (!empty($this->parts)) {
             return $this->parts; // no ExtenderFacade

--- a/Okay/Helpers/MetadataHelpers/BlogCategoryMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/BlogCategoryMetadataHelper.php
@@ -13,7 +13,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         $category = $this->design->getVar('category');
 
@@ -21,7 +21,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
         if ($pageH1 = parent::getH1Template()) {
             $h1 = $pageH1;
         } else {
-            $h1 = $categoryH1;
+            $h1 = (string)$categoryH1;
         }
 
         return ExtenderFacade::execute(__METHOD__, $h1, func_get_args());
@@ -30,7 +30,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getAnnotationTemplate() : string
+    public function getAnnotationTemplate(): string
     {
         $category = $this->design->getVar('category');
         $isAllPages = $this->design->getVar('is_all_pages');
@@ -41,7 +41,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
         } elseif ($pageAnnotation = parent::getAnnotationTemplate()) {
             $annotation = $pageAnnotation;
         } else {
-            $annotation = $category->annotation;
+            $annotation = (string)$category->annotation;
         }
 
         return ExtenderFacade::execute(__METHOD__, $annotation, func_get_args());
@@ -50,7 +50,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         $category = $this->design->getVar('category');
         $isAllPages = $this->design->getVar('is_all_pages');
@@ -61,13 +61,13 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
         } elseif ($pageDescription = parent::getDescriptionTemplate()) {
             $description = $pageDescription;
         } else {
-            $description = $category->description;
+            $description = (string)$category->description;
         }
 
         return ExtenderFacade::execute(__METHOD__, $description, func_get_args());
     }
     
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         $category = $this->design->getVar('category');
         $isAllPages = $this->design->getVar('is_all_pages');
@@ -76,7 +76,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
         if ($pageTitle = parent::getMetaTitleTemplate()) {
             $metaTitle = $pageTitle;
         } else {
-            $metaTitle = $category->meta_title;
+            $metaTitle = (string)$category->meta_title;
         }
 
         // Добавим номер страницы к тайтлу
@@ -89,27 +89,27 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $metaTitle, func_get_args());
     }
     
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         $category = $this->design->getVar('category');
         
         if ($pageKeywords = parent::getMetaKeywordsTemplate()) {
             $metaKeywords = $pageKeywords;
         } else {
-            $metaKeywords = $category->meta_keywords;
+            $metaKeywords = (string)$category->meta_keywords;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaKeywords, func_get_args());
     }
     
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         $category = $this->design->getVar('category');
         
         if ($pageMetaDescription = parent::getMetaDescriptionTemplate()) {
             $metaDescription = $pageMetaDescription;
         } else {
-            $metaDescription = $category->meta_description;
+            $metaDescription = (string)$category->meta_description;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaDescription, func_get_args());
@@ -118,7 +118,7 @@ class BlogCategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    protected function getParts() : array
+    protected function getParts(): array
     {
 
         if (!empty($this->parts)) {

--- a/Okay/Helpers/MetadataHelpers/BrandMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/BrandMetadataHelper.php
@@ -25,7 +25,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         $brand = $this->design->getVar('brand');
         $filterAutoMeta = $this->getFilterAutoMeta();
@@ -35,7 +35,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMeta->h1)) {
             $h1 = $brand->name . ' ' . $filterAutoMeta->h1;
         } else {
-            $h1 = $brand->name;
+            $h1 = (string)$brand->name;
         }
 
         return ExtenderFacade::execute(__METHOD__, $h1, func_get_args());
@@ -44,13 +44,13 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getAnnotationTemplate() : string
+    public function getAnnotationTemplate(): string
     {
         $brand = $this->design->getVar('brand');
         $isFilterPage = $this->design->getVar('is_filter_page');
         $isAllPages = $this->design->getVar('is_all_pages');
         $currentPageNum = $this->design->getVar('current_page_num');
-        $filterAutoMeta = $this->getFilterAutoMeta();
+//        $filterAutoMeta = $this->getFilterAutoMeta();
 
         if ((int)$currentPageNum > 1 || $isAllPages === true) {
             $annotation = '';
@@ -59,7 +59,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
         /*} elseif (!empty($filterAutoMeta->annotation)) {
             $description = $filterAutoMeta->annotation;*/
         } elseif ($isFilterPage === false) {
-            $annotation = $brand->annotation;
+            $annotation = (string)$brand->annotation;
         } else {
             $annotation = '';
         }
@@ -70,13 +70,13 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         $brand = $this->design->getVar('brand');
         $isFilterPage = $this->design->getVar('is_filter_page');
         $isAllPages = $this->design->getVar('is_all_pages');
         $currentPageNum = $this->design->getVar('current_page_num');
-        $filterAutoMeta = $this->getFilterAutoMeta();
+//        $filterAutoMeta = $this->getFilterAutoMeta();
 
         if ((int)$currentPageNum > 1 || $isAllPages === true) {
             $description = '';
@@ -85,7 +85,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
         /*} elseif (!empty($filterAutoMeta->description)) {
             $description = $filterAutoMeta->description;*/
         } elseif ($isFilterPage === false) {
-            $description = $brand->description;
+            $description = (string)$brand->description;
         } else {
             $description = '';
         }
@@ -96,7 +96,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         $brand = $this->design->getVar('brand');
         $filterAutoMeta = $this->getFilterAutoMeta();
@@ -108,7 +108,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMeta->meta_title)) {
             $metaTitle = $brand->meta_title . ' ' . $filterAutoMeta->meta_title;
         } else {
-            $metaTitle = $brand->meta_title;
+            $metaTitle = (string)$brand->meta_title;
         }
 
         // Добавим номер страницы к тайтлу
@@ -124,7 +124,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         $brand = $this->design->getVar('brand');
         $filterAutoMeta = $this->getFilterAutoMeta();
@@ -134,7 +134,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMeta->meta_keywords)) {
             $metaKeywords = $brand->meta_keywords . ' ' . $filterAutoMeta->meta_keywords;
         } else {
-            $metaKeywords = $brand->meta_keywords;
+            $metaKeywords = (string)$brand->meta_keywords;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaKeywords, func_get_args());
@@ -143,7 +143,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         $brand = $this->design->getVar('brand');
         $filterAutoMeta = $this->getFilterAutoMeta();
@@ -153,7 +153,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMeta->meta_description)) {
             $metaDescription = $brand->meta_description . ' ' . $filterAutoMeta->meta_description;
         } else {
-            $metaDescription = $brand->meta_description;
+            $metaDescription = (string)$brand->meta_description;
         }
         
         return ExtenderFacade::execute(__METHOD__, $metaDescription, func_get_args());
@@ -168,8 +168,8 @@ class BrandMetadataHelper extends CommonMetadataHelper
 
             $metaArray = $this->getMetaArray();
 
-            $currentPage = isset($metaArray['page']) ? $metaArray['page'] : null;
-            $currentOtherFilters = isset($metaArray['filter']) ? $metaArray['filter'] : [];
+            $currentPage = $metaArray['page'] ?? null;
+            $currentOtherFilters = $metaArray['filter'] ?? [];
 
             $this->metaRobots = $metaRobotsHelper->getCatalogRobots($currentPage, $currentOtherFilters);
         }
@@ -210,7 +210,7 @@ class BrandMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    protected function getParts() : array
+    protected function getParts(): array
     {
         if (!empty($this->parts)) {
             return $this->parts; // no ExtenderFacade

--- a/Okay/Helpers/MetadataHelpers/CartMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/CartMetadataHelper.php
@@ -9,7 +9,7 @@ use Okay\Core\Modules\Extender\ExtenderFacade;
 
 class CartMetadataHelper extends CommonMetadataHelper
 {
-    public function getMetaTitle() : string
+    public function getMetaTitle(): string
     {
         /** @var FrontTranslations $translations */
         $translations = $this->SL->getService(FrontTranslations::class);
@@ -17,12 +17,12 @@ class CartMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $metaTitle, func_get_args());
     }
     
-    public function getMetaKeywords() : string
+    public function getMetaKeywords(): string
     {
         return ExtenderFacade::execute(__METHOD__, '', func_get_args());
     }
     
-    public function getMetaDescription() : string
+    public function getMetaDescription(): string
     {
         return ExtenderFacade::execute(__METHOD__, '', func_get_args());
     }

--- a/Okay/Helpers/MetadataHelpers/CategoryMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/CategoryMetadataHelper.php
@@ -28,7 +28,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         $category = $this->design->getVar('category');
         $seoFilterPattern = $this->getSeoFilterPattern();
@@ -44,7 +44,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $h1, func_get_args());
     }
 
-    public function matchPriorityH1($pageH1, $seoFilterPatternH1, $filterAutoMetaH1, $categoryH1)
+    public function matchPriorityH1($pageH1, $seoFilterPatternH1, $filterAutoMetaH1, $categoryH1): string
     {
         if ($pageH1) {
             $h1 = $pageH1;
@@ -62,7 +62,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getAnnotationTemplate() : string
+    public function getAnnotationTemplate(): string
     {
         $category = $this->design->getVar('category');
         $isFilterPage = $this->design->getVar('is_filter_page');
@@ -82,7 +82,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         $category = $this->design->getVar('category');
         $isFilterPage = $this->design->getVar('is_filter_page');
@@ -100,7 +100,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $description, func_get_args());
     }
 
-    public function matchPriorityDescription($currentPageNum, $isAllPages, $pageDescription, $seoFilterPatternDescription, $filterAutoMetaDescription, $isFilterPage, $categoryDescription)
+    public function matchPriorityDescription($currentPageNum, $isAllPages, $pageDescription, $seoFilterPatternDescription, $filterAutoMetaDescription, $isFilterPage, $categoryDescription): string
     {
         if ((int)$currentPageNum > 1 || $isAllPages === true) {
             $description = '';
@@ -111,7 +111,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         /*} elseif (!empty($filterAutoMetaDescription)) {
             $description = $filterAutoMetaDescription;*/
         } elseif ($isFilterPage === false) {
-            $description = $categoryDescription;
+            $description = (string)$categoryDescription;
         } else {
             $description = '';
         }
@@ -119,7 +119,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $description, func_get_args());
     }
     
-    public function getMetaTitleTemplate() : string // todo проверить как отработают экстендеры если их навесить на этот метод (где юзается parent::getMetaTitle())
+    public function getMetaTitleTemplate(): string // todo проверить как отработают экстендеры если их навесить на этот метод (где юзается parent::getMetaTitle())
     {
         $category = $this->design->getVar('category');
         $seoFilterPattern = $this->getSeoFilterPattern();
@@ -143,7 +143,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $metaTitle, func_get_args());
     }
 
-    public function matchPriorityMetaTitle($pageTitle, $seoFilterPatternMetaTitle, $filterAutoMetaTitle, $categoryMetaTitle)
+    public function matchPriorityMetaTitle($pageTitle, $seoFilterPatternMetaTitle, $filterAutoMetaTitle, $categoryMetaTitle): string
     {
         if ($pageTitle) {
             $metaTitle = $pageTitle;
@@ -152,13 +152,13 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMetaTitle)) {
             $metaTitle = $categoryMetaTitle . ' ' . $filterAutoMetaTitle;
         } else {
-            $metaTitle = $categoryMetaTitle;
+            $metaTitle = (string)$categoryMetaTitle;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaTitle, func_get_args());
     }
 
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         $category = $this->design->getVar('category');
         $seoFilterPattern = $this->getSeoFilterPattern();
@@ -173,7 +173,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $metaKeywords, func_get_args());
     }
 
-    public function matchPriorityMetaKeywords($pageKeywords, $seoFilterPatternMetaKeywords, $filterAutoMetaMetaKeywords, $categoryMetaKeywords)
+    public function matchPriorityMetaKeywords($pageKeywords, $seoFilterPatternMetaKeywords, $filterAutoMetaMetaKeywords, $categoryMetaKeywords): string
     {
         if ($pageKeywords) {
             $metaKeywords = $pageKeywords;
@@ -182,13 +182,13 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMetaMetaKeywords)) {
             $metaKeywords = $categoryMetaKeywords . ' ' . $filterAutoMetaMetaKeywords;
         } else {
-            $metaKeywords = $categoryMetaKeywords;
+            $metaKeywords = (string)$categoryMetaKeywords;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaKeywords, func_get_args());
     }
     
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         $category = $this->design->getVar('category');
         $seoFilterPattern = $this->getSeoFilterPattern();
@@ -203,7 +203,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $metaDescription, func_get_args());
     }
 
-    public function matchPriorityMetaDescription($pageMetaDescription, $seoFilterPatternMetaDescription, $filterAutoMetaMetaDescription, $categoryMetaDescription)
+    public function matchPriorityMetaDescription($pageMetaDescription, $seoFilterPatternMetaDescription, $filterAutoMetaMetaDescription, $categoryMetaDescription): string
     {
         if ($pageMetaDescription) {
             $metaDescription = $pageMetaDescription;
@@ -212,7 +212,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
         } elseif (!empty($filterAutoMetaMetaDescription)) {
             $metaDescription = $categoryMetaDescription . ' ' . $filterAutoMetaMetaDescription;
         } else {
-            $metaDescription = $categoryMetaDescription;
+            $metaDescription = (string)$categoryMetaDescription;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaDescription, func_get_args());
@@ -284,7 +284,7 @@ class CategoryMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    protected function getParts() : array
+    protected function getParts(): array
     {
 
         if (!empty($this->parts)) {

--- a/Okay/Helpers/MetadataHelpers/CommonMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/CommonMetadataHelper.php
@@ -45,12 +45,12 @@ class CommonMetadataHelper implements MetadataInterface
         $this->page = $this->design->getVar('page');
     }
 
-    public function setUp() : void {}
+    public function setUp(): void {}
     
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         if (empty($this->h1) && $this->page) {
             $this->h1 = $this->page->name_h1 ?? $this->page->name;
@@ -62,7 +62,7 @@ class CommonMetadataHelper implements MetadataInterface
     /**
      * @inheritDoc
      */
-    public function getAnnotationTemplate() : string
+    public function getAnnotationTemplate(): string
     {
         return ExtenderFacade::execute([static::class, __FUNCTION__], $this->annotation, func_get_args());
     }
@@ -70,7 +70,7 @@ class CommonMetadataHelper implements MetadataInterface
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         if (empty($this->description) && $this->page) {
             $this->description = $this->page->description;
@@ -82,7 +82,7 @@ class CommonMetadataHelper implements MetadataInterface
     /**
      * @inheritDoc
      */
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         if (empty($this->metaTitle) && $this->page) {
             $this->metaTitle = $this->page->meta_title;
@@ -94,7 +94,7 @@ class CommonMetadataHelper implements MetadataInterface
     /**
      * @inheritDoc
      */
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         if (empty($this->metaKeywords) && $this->page) {
             $this->metaKeywords = $this->page->meta_keywords;
@@ -106,7 +106,7 @@ class CommonMetadataHelper implements MetadataInterface
     /**
      * @inheritDoc
      */
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         if (empty($this->metaDescription) && $this->page) {
             $this->metaDescription = $this->page->meta_description;
@@ -115,37 +115,37 @@ class CommonMetadataHelper implements MetadataInterface
         return ExtenderFacade::execute([static::class, __FUNCTION__], $this->metaDescription, func_get_args());
     }
     
-    public function getH1() : string
+    public function getH1(): string
     {
         $h1 = $this->compileMetadata($this->getH1Template());
         return ExtenderFacade::execute([static::class, __FUNCTION__], $h1, func_get_args());
     }
 
-    public function getAnnotation() : string
+    public function getAnnotation(): string
     {
         $annotation = $this->compileMetadata($this->getAnnotationTemplate());
         return ExtenderFacade::execute([static::class, __FUNCTION__], $annotation, func_get_args());
     }
 
-    public function getDescription() : string
+    public function getDescription(): string
     {
         $description = $this->compileMetadata($this->getDescriptionTemplate());
         return ExtenderFacade::execute([static::class, __FUNCTION__], $description, func_get_args());
     }
 
-    public function getMetaTitle() : string
+    public function getMetaTitle(): string
     {
         $title = $this->compileMetadata($this->getMetaTitleTemplate());
         return ExtenderFacade::execute([static::class, __FUNCTION__], $title, func_get_args());
     }
 
-    public function getMetaKeywords() : string
+    public function getMetaKeywords(): string
     {
         $keywords = $this->compileMetadata($this->getMetaKeywordsTemplate());
         return ExtenderFacade::execute([static::class, __FUNCTION__], $keywords, func_get_args());
     }
 
-    public function getMetaDescription() : string
+    public function getMetaDescription(): string
     {
         $description = $this->compileMetadata($this->getMetaDescriptionTemplate());
         return ExtenderFacade::execute([static::class, __FUNCTION__], $description, func_get_args());
@@ -154,7 +154,7 @@ class CommonMetadataHelper implements MetadataInterface
     /**
      * @return array
      */
-    protected function getParts() : array
+    protected function getParts(): array
     {
         if (!empty($this->parts)) {
             return $this->parts; // no ExtenderFacade

--- a/Okay/Helpers/MetadataHelpers/MetadataInterface.php
+++ b/Okay/Helpers/MetadataHelpers/MetadataInterface.php
@@ -7,41 +7,41 @@ namespace Okay\Helpers\MetadataHelpers;
 interface MetadataInterface
 {
     /** @return void */
-    public function setUp() : void;
+    public function setUp(): void;
     
     /** @return string */
-    public function getH1() : string;
+    public function getH1(): string;
 
     /** @return string */
-    public function getAnnotation() : string;
+    public function getAnnotation(): string;
 
     /** @return string */
-    public function getDescription() : string;
+    public function getDescription(): string;
 
     /** @return string */
-    public function getMetaTitle() : string;
+    public function getMetaTitle(): string;
 
     /** @return string */
-    public function getMetaKeywords() : string;
+    public function getMetaKeywords(): string;
 
     /** @return string */
-    public function getMetaDescription() : string;
+    public function getMetaDescription(): string;
     
     /** @return string */
-    public function getH1Template() : string;
+    public function getH1Template(): string;
 
     /** @return string */
-    public function getAnnotationTemplate() : string;
+    public function getAnnotationTemplate(): string;
 
     /** @return string */
-    public function getDescriptionTemplate() : string;
+    public function getDescriptionTemplate(): string;
 
     /** @return string */
-    public function getMetaTitleTemplate() : string;
+    public function getMetaTitleTemplate(): string;
 
     /** @return string */
-    public function getMetaKeywordsTemplate() : string;
+    public function getMetaKeywordsTemplate(): string;
 
     /** @return string */
-    public function getMetaDescriptionTemplate() : string;
+    public function getMetaDescriptionTemplate(): string;
 }

--- a/Okay/Helpers/MetadataHelpers/OrderMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/OrderMetadataHelper.php
@@ -9,7 +9,7 @@ use Okay\Core\Modules\Extender\ExtenderFacade;
 
 class OrderMetadataHelper extends CommonMetadataHelper
 {
-    public function getMetaTitle() : string
+    public function getMetaTitle(): string
     {
         $order = $this->design->getVar('order');
         /** @var FrontTranslations $translations */
@@ -18,12 +18,12 @@ class OrderMetadataHelper extends CommonMetadataHelper
         return ExtenderFacade::execute(__METHOD__, $metaTitle, func_get_args());
     }
     
-    public function getMetaKeywords() : string
+    public function getMetaKeywords(): string
     {
         return ExtenderFacade::execute(__METHOD__, '', func_get_args());
     }
     
-    public function getMetaDescription() : string
+    public function getMetaDescription(): string
     {
         return ExtenderFacade::execute(__METHOD__, '', func_get_args());
     }

--- a/Okay/Helpers/MetadataHelpers/PostMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/PostMetadataHelper.php
@@ -17,78 +17,78 @@ class PostMetadataHelper extends CommonMetadataHelper
 {
  
 
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         $post = $this->design->getVar('post');
 
         if ($pageH1 = parent::getH1Template()) {
             $h1 = $pageH1;
         } else {
-            $h1 = $post->name;
+            $h1 = (string)$post->name;
         }
         
         return ExtenderFacade::execute(__METHOD__, $h1, func_get_args());
     }
     
-    public function getAnnotationTemplate() : string
+    public function getAnnotationTemplate(): string
     {
         $post = $this->design->getVar('post');
         
         if ($pageAnnotation = parent::getAnnotationTemplate()) {
             $annotation = $pageAnnotation;
         } else {
-            $annotation = $post->annotation;
+            $annotation = (string)$post->annotation;
         }
 
         return ExtenderFacade::execute(__METHOD__, $annotation, func_get_args());
     }
     
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         $post = $this->design->getVar('post');
         
         if ($pageDescription = parent::getDescriptionTemplate()) {
             $description = $pageDescription;
         } else {
-            $description = $post->description;
+            $description = (string)$post->description;
         }
 
         return ExtenderFacade::execute(__METHOD__, $description, func_get_args());
     }
     
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         $post = $this->design->getVar('post');
         if ($pageTitle = parent::getMetaTitleTemplate()) {
             $metaTitle = $pageTitle;
         } else {
-            $metaTitle = $post->meta_title;
+            $metaTitle = (string)$post->meta_title;
         }
         
         return ExtenderFacade::execute(__METHOD__, $metaTitle, func_get_args());
     }
     
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         $post = $this->design->getVar('post');
         
         if ($pageKeywords = parent::getMetaKeywordsTemplate()) {
             $metaKeywords = $pageKeywords;
         } else {
-            $metaKeywords = $post->meta_keywords;
+            $metaKeywords = (string)$post->meta_keywords;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaKeywords, func_get_args());
     }
     
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         $post = $this->design->getVar('post');
         
         if ($pageMetaDescription = parent::getMetaDescriptionTemplate()) {
             $metaDescription = $pageMetaDescription;
         } else {
-            $metaDescription = $post->meta_description;
+            $metaDescription = (string)$post->meta_description;
         }
 
         return ExtenderFacade::execute(__METHOD__, $metaDescription, func_get_args());

--- a/Okay/Helpers/MetadataHelpers/ProductMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/ProductMetadataHelper.php
@@ -12,7 +12,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     private $categoryPath;
     private $product;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
         $this->category = $this->design->getVar('category');
@@ -23,7 +23,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getH1Template() : string
+    public function getH1Template(): string
     {
         $defaultProductsSeoPattern = (object)$this->settings->get('default_products_seo_pattern');
 
@@ -43,7 +43,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getAnnotationTemplate() : string
+    public function getAnnotationTemplate(): string
     {
         $defaultProductsSeoPattern = (object)$this->settings->get('default_products_seo_pattern');
         $annotation = $this->product->annotation;
@@ -61,7 +61,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getDescriptionTemplate() : string
+    public function getDescriptionTemplate(): string
     {
         $defaultProductsSeoPattern = (object)$this->settings->get('default_products_seo_pattern');
         $description = $this->product->description;
@@ -79,7 +79,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaTitleTemplate() : string
+    public function getMetaTitleTemplate(): string
     {
         $defaultProductsSeoPattern = (object)$this->settings->get('default_products_seo_pattern');
 
@@ -97,7 +97,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaKeywordsTemplate() : string
+    public function getMetaKeywordsTemplate(): string
     {
         $defaultProductsSeoPattern = (object)$this->settings->get('default_products_seo_pattern');
 
@@ -115,7 +115,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
     /**
      * @inheritDoc
      */
-    public function getMetaDescriptionTemplate() : string
+    public function getMetaDescriptionTemplate(): string
     {
         $defaultProductsSeoPattern = (object)$this->settings->get('default_products_seo_pattern');
 
@@ -134,7 +134,7 @@ class ProductMetadataHelper extends CommonMetadataHelper
      * Метод возвращает массив переменных и их значений, который учавствуют в формировании метаданных
      * @return array
      */
-    protected function getParts() : array
+    protected function getParts(): array
     {
         if (!empty($this->parts)) {
             return $this->parts; // no ExtenderFacade


### PR DESCRIPTION
### Что PR делает?

Добавляет приведение к типу "string" в MetadataHelpers во всех случаях, когда мы не можем быть уверены в типе данных.

### Зачем PR нужен?

Строгая типизация и соответствие логике кода.