### PR TITLE
Не показывать метку "Предзаказ", когда флаг заказа closed

### DIFF
--- a/backend/Controllers/OrderAdmin.php
+++ b/backend/Controllers/OrderAdmin.php
@@ -177,7 +177,7 @@ class OrderAdmin extends IndexAdmin
             $subtotal = 0;
             $hasVariantNotInStock = false;
             foreach ($purchases as $purchase) {
-                if ((empty($purchase->variant) || $purchase->amount > $purchase->variant->stock || !$purchase->variant->stock) && !$hasVariantNotInStock) {
+                if (!$order->closed && ((empty($purchase->variant) || $purchase->amount > $purchase->variant->stock || !$purchase->variant->stock) && !$hasVariantNotInStock)) {
                     $hasVariantNotInStock = true;
                 }
                 $subtotal += $purchase->price * $purchase->amount;

--- a/backend/design/html/email/email_order_admin.tpl
+++ b/backend/design/html/email/email_order_admin.tpl
@@ -272,7 +272,7 @@
                                                                                             <td>
                                                                                                 <a href="{url_generator route='product' url=$purchase->product->url absolute=1}" style="font-family: 'Trebuchet MS';font-size: 16px;color: #222;text-decoration: none;line-height: normal;">{$purchase->product_name|escape}</a><br />
                                                                                                 <span class="es-p5t"><em><span style="color: rgb(128, 128, 128); font-size: 12px;">{$purchase->variant_name|escape}</span></em></span>
-                                                                                                {if $purchase->variant->stock == 0}
+                                                                                                {if !$order->closed && $purchase->variant->stock == 0}
                                                                                                 <div class="es-p5t" style="color: #000; font-size: 12px;font-weight: 600">{$lang->product_pre_order|escape}</div>
                                                                                                 {/if}
                                                                                                 {get_design_block block="email_order_admin_purchase_name" vars=['purchase' => $purchase]}

--- a/backend/design/html/order.tpl
+++ b/backend/design/html/order.tpl
@@ -198,7 +198,7 @@
                                                 <div class="okay_list_boding okay_list_order_name">
                                                     <div class="boxes_inline">
                                                         {if $purchase->product}
-                                                            <a class="text_600 {if $purchase->variant->stock == 0}hint-bottom-middle-t-info-s-small-mobile  hint-anim text_500 text_warning{/if}" {if $purchase->variant->stock == 0}data-hint="{$btr->product_out_stock|escape}"{/if} href="{url controller=ProductAdmin id=$purchase->product->id}">{$purchase->product_name|escape}</a>
+                                                            <a class="text_600 {if !$order->closed && $purchase->variant->stock == 0}hint-bottom-middle-t-info-s-small-mobile  hint-anim text_500 text_warning{/if}" {if !$order->closed && $purchase->variant->stock == 0}data-hint="{$btr->product_out_stock|escape}"{/if} href="{url controller=ProductAdmin id=$purchase->product->id}">{$purchase->product_name|escape}</a>
                                                             {if $purchase->variant_name}
                                                                 <div class="mt-q font_12"><span class="text_grey">{$btr->order_option|escape}</span> {$purchase->variant_name|escape}</div>
                                                             {/if}

--- a/design/okay_shop/html/email/email_order.tpl
+++ b/design/okay_shop/html/email/email_order.tpl
@@ -269,7 +269,7 @@
                                                                                     <td>
                                                                                         <a href="{url_generator route='product' url=$purchase->product->url absolute=1}" style="font-family: 'Trebuchet MS';font-size: 16px;color: #222;text-decoration: none;line-height: normal;">{$purchase->product_name|escape}</a><br />
                                                                                         <span class="es-p5t"><em><span style="color: rgb(128, 128, 128); font-size: 12px;">{$purchase->variant_name|escape}</span></em></span>
-                                                                                        {if $purchase->variant->stock == 0}
+                                                                                        {if !$order->closed && $purchase->variant->stock == 0}
                                                                                         <div class="es-p5t" style="color: #000; font-size: 12px;font-weight: 600">{$lang->product_pre_order}</div>
                                                                                         {/if}
                                                                                         {get_design_block block="front_email_order_user_purchase_name" vars=['purchase' => $purchase]}

--- a/design/okay_shop/html/order.tpl
+++ b/design/okay_shop/html/order.tpl
@@ -43,7 +43,7 @@
                                         <div class="purchase__name">
                                             <a class="purchase__name_link" href="{url_generator route="product" url=$purchase->product->url}">{$purchase->product_name|escape}</a>
                                             <i>{$purchase->variant_name|escape}</i>
-                                            {if $purchase->variant->stock == 0}<span class="preorder_label">{$lang->product_pre_order}</span>{/if}
+                                            {if !$order->closed && $purchase->variant->stock == 0}<span class="preorder_label">{$lang->product_pre_order}</span>{/if}
 
                                         </div>
                                         <div class="purchase__group">

--- a/design/okay_shop/html/user.tpl
+++ b/design/okay_shop/html/user.tpl
@@ -249,7 +249,7 @@
                                                             <div class="purchase__name">
                                                                 <a class="purchase__name_link" href="{url_generator route="product" url=$purchase->product->url}">{$purchase->product_name|escape}</a>
                                                                 <i>{$purchase->variant_name|escape}</i>
-                                                                {if $purchase->variant->stock == 0}<span class="preorder_label">{$lang->product_pre_order}</span>{/if}
+                                                                {if !$order->closed && $purchase->variant->stock == 0}<span class="preorder_label">{$lang->product_pre_order}</span>{/if}
                     
                                                             </div>
                                                             <div class="purchase__group">


### PR DESCRIPTION
### Что PR делает?
На фронте:
В ЛК пользователя, на странице оформленного заказа (Thank You Page)
На бэке: 
на странице конкретного заказа
В письмах:
о заказе пользователю и админу
В контроллере OrderAdmin

Были добавлены проверки на то, не закрыт ли заказ (order->closed)

### Зачем PR нужен?

Когда товар списывался при смене статуса (из функциональности Заказы-Настройка заказов-Статусы заказов: Название статуса -> настройка для статуса "Списывать товары"), то даже у заказа который списал эти самые товары может появится метка в OrderAdmin (hasVariantNotInStock), что не все товары есть в наличии, а так же клиенту показывается списанный товар с пометкой "предзаказ". 

Было решено всем закрытым заказам (closed = списанные товары) не выводить перечисленную выше информацию о предзаказе и отсутствии товара в наличии.

