### PR TITLE
Bugfix/fix filter features

### DIFF
--- a/Okay/Entities/ProductsEntity.php
+++ b/Okay/Entities/ProductsEntity.php
@@ -707,6 +707,11 @@ class ProductsEntity extends Entity implements RelatedProductsInterface
             ]);
         }
 
+        $c = 0;
+        foreach ($filter['features'] as $f) {
+            $c += count($f);
+        }
+
         if (!empty($featuresValues)) {
 
             if (!empty($filter['visible'])) {
@@ -718,7 +723,7 @@ class ProductsEntity extends Entity implements RelatedProductsInterface
                 ->cols(['DISTINCT(pf.product_id)'])
                 ->where('(' . implode(' OR ', $featuresValues) . ')')
                 ->join('LEFT', '__features_values AS fv', 'fv.id=pf.value_id')
-                ->having('COUNT(*) >=' . count($features))
+                ->having('COUNT(*) >=' . $c)
                 ->groupBy(['product_id']);
 
             $this->select->joinSubSelect(


### PR DESCRIPTION
### Что PR делает?

Добавлен счетчик, который считает кол-во выбранных значений свойств (feature_values). И он учитывается в запросе вместо кол-ва свойств (features)

### Зачем PR нужен?

Из-за того, что выборка товаров на основе выбранных feature_values считало по кол-ву features в HAVING, то в результат попадали товары, которые подходят по некоторым из выбранных значений, а не по всем, Тк значений может быть больше чем свойств.  Проблема наблюдалась на сайте, где у каждого товара в свойствах используются несколько значений. И когда фильтровалось по 'мальчик' и другим значениям в результат попадали товары у которых значение было и 'девочка'.  Фикс помог решить эту проблему 
