### PR TITLE
Unsetting unique indexes from lang fields when migrating a table

### DIFF
--- a/Okay/Core/Modules/EntityField.php
+++ b/Okay/Core/Modules/EntityField.php
@@ -291,6 +291,12 @@ class EntityField
         ];
         return $this;
     }
+
+    public function unsetIndexUnique()
+    {
+        unset($this->indexes[self::INDEX_UNIQUE]);
+        return $this;
+    }
     
     public function getIndexes()
     {

--- a/Okay/Core/Modules/EntityMigrator.php
+++ b/Okay/Core/Modules/EntityMigrator.php
@@ -68,6 +68,7 @@ class EntityMigrator
         $langEntityFields[] = (new EntityField($langObjectField))->setTypeInt(11);
         foreach ($entityFields as $entityField) {
             if ($entityField->isLangField()) {
+                $entityField->unsetIndexUnique();
                 $langEntityFields[] = $entityField;
             }
         }


### PR DESCRIPTION
### Что PR делает?

Удаляет уникальные индексы у полей перед созданием языковых таблиц в базе.

### Зачем PR нужен?

Даже если в основной таблице некоторые поля должны быть уникальными, то в языковой они не могут быть уникальными в силу дублирования на разных языках.