### PR TITLE
Change the order of the getFilter method call lines in Brand and Products Controllers so that the getPrice call methods work correctly

### DIFF
--- a/Okay/Controllers/BrandController.php
+++ b/Okay/Controllers/BrandController.php
@@ -98,6 +98,8 @@ class BrandController extends AbstractController
         
         $this->design->assign('other_filters', $catalogHelper->getOtherFilters($filter));
 
+        $filter = $filterHelper->getBrandProductsFilter($filter);
+
         if ((!empty($filter['price']) && $filter['price']['min'] !== '' && $filter['price']['max'] !== '' && $filter['price']['min'] !== null) || !empty($filter['other_filter'])) {
             $isFilterPage = true;
         }
@@ -105,8 +107,6 @@ class BrandController extends AbstractController
         
         $prices = $catalogHelper->getPrices($filter, $this->catalogType, $brand->id);
         $this->design->assign('prices', $prices);
-
-        $filter = $filterHelper->getBrandProductsFilter($filter);
 
         if ($filter === false) {
             return false;

--- a/Okay/Controllers/ProductsController.php
+++ b/Okay/Controllers/ProductsController.php
@@ -100,13 +100,6 @@ class ProductsController extends AbstractController
         if ($catalogType == 'search') {
             $this->design->assign('other_filters', $catalogHelper->getOtherFilters($filter));
         }
-
-        if ((!empty($filter['price']) && $filter['price']['min'] !== '' && $filter['price']['max'] !== '' && $filter['price']['min'] !== null) || !empty($filter['other_filter'])) {
-            $this->design->assign('is_filter_page', true);
-        }
-        
-        $prices = $catalogHelper->getPrices($filter, $catalogType);
-        $this->design->assign('prices', $prices);
         
         switch ($catalogType) {
             case 'bestsellers':
@@ -125,6 +118,13 @@ class ProductsController extends AbstractController
                 }
                 break;
         }
+
+        if ((!empty($filter['price']) && $filter['price']['min'] !== '' && $filter['price']['max'] !== '' && $filter['price']['min'] !== null) || !empty($filter['other_filter'])) {
+            $this->design->assign('is_filter_page', true);
+        }
+
+        $prices = $catalogHelper->getPrices($filter, $catalogType);
+        $this->design->assign('prices', $prices);
 
         if ($filter === false) {
             return false;


### PR DESCRIPTION

### Что PR делает?

В контроллерах  BrandController и ProductsController был изменен порядок вызова методов по типу getFilter.

Для BrandController :
getBrandProductsFilter

Для ProductsController:
getFeaturedProductsFilter
getDiscountedProductsFilter
getSearchProductsFilter



### Зачем PR нужен?

Стандартный порядок вызова методов по типу getFilter срабатывал после метода getPrices (который возвращает диапазон цен товаров для фильтрации ползунком например), что приводило к некорректной работе метода getPrices. В getPrices не попадали изменения, которые могут делать модули зацепившиеся за ExtenderFacade к методам по типу getFilter. Кроме того в ProductsController метод getSearchProductsFilter так же не влиял на изменение диапазона цен, который возвращает getPrices, т.к. в нём уже задается фильтр товара по keyword  ( $filter['keyword'] = $keyword;)

