### PR TITLE
fixed h1 on bestsellers, discounts, all-page etc

### DIFF
--- a/Okay/Helpers/MetadataHelpers/CommonMetadataHelper.php
+++ b/Okay/Helpers/MetadataHelpers/CommonMetadataHelper.php
@@ -53,7 +53,7 @@ class CommonMetadataHelper implements MetadataInterface
     public function getH1Template(): string
     {
         if (empty($this->h1) && $this->page) {
-            $this->h1 = $this->page->name_h1 ?? $this->page->name;
+            $this->h1 = empty($this->page->name_h1) ? $this->page->name : $this->page->name_h1;
         }
         
         return ExtenderFacade::execute([static::class, __FUNCTION__], $this->h1, func_get_args());


### PR DESCRIPTION
### Что PR делает?

изменен ?? на проверку на пустоту, тк h1 установлен, но пустой И на зарезервированных страницах с пустым h1 не выводились хлебные крошки и заголовок страницы

### Зачем PR нужен?

пусто в хлебных крошках и заголовка нет (плохо для SEO)