### PR TITLE
Fixed bugs in product PrefixAndPathStrategy

### DIFF
--- a/Okay/Core/Routes/Strategies/Product/PrefixAndPathStrategy.php
+++ b/Okay/Core/Routes/Strategies/Product/PrefixAndPathStrategy.php
@@ -76,7 +76,7 @@ class PrefixAndPathStrategy extends AbstractRouteStrategy
             $this->logger->warning('Missing "main_category_id" for product "'.$url.'"');
         } else {
             $category = $this->categoriesEntity->get((int) $product->main_category_id);
-            $slug = substr($category->path_url, 1).'/'.$product->url;
+            $slug = $category->path_url.'/'.$product->url;
         }
 
         // Запоминаем в оперативке slug для этого урла
@@ -192,7 +192,6 @@ class PrefixAndPathStrategy extends AbstractRouteStrategy
 
             return $sortCategories($mappedByParentCategories[$category->id]);
         };
-
         $mostNestedCategory = $sortCategories(reset($mappedByParentCategories));
         return $mostNestedCategory->id;
     }
@@ -207,7 +206,7 @@ class PrefixAndPathStrategy extends AbstractRouteStrategy
             $categoriesMappedByParent[$category->parent_id] = $category;
         }
 
-        return array_values($categoriesMappedByParent);
+        return $categoriesMappedByParent;
     }
 
     private function prefixIsFailed($prefix, $url) : bool


### PR DESCRIPTION
### Что PR делает?

В стратегии товара PrefixAndPath больше не обрезаем первый символ. Там же теперь корректно мапим массив категорий

### Зачем PR нужен?

Чтобы корректно генерировать урлы и корректно их парсить.