### PR TITLE
Bugfix/filter front translations

### DIFF
--- a/Okay/Core/config/helpers.php
+++ b/Okay/Core/config/helpers.php
@@ -466,6 +466,7 @@ return [
             new SR(Router::class),
             new SR(Design::class),
             new SR(Money::class),
+            new SR(FrontTranslations::class),
         ],
     ],
     MoneyHelper::class => [

--- a/Okay/Helpers/FilterHelper.php
+++ b/Okay/Helpers/FilterHelper.php
@@ -6,6 +6,7 @@ namespace Okay\Helpers;
 
 use Okay\Core\Design;
 use Okay\Core\EntityFactory;
+use Okay\Core\FrontTranslations;
 use Okay\Core\Languages;
 use Okay\Core\Money;
 use Okay\Core\Request;
@@ -27,6 +28,7 @@ class FilterHelper
     private $design;
     private $settings;
     private $money;
+    private $frontTranslations;
     
     private $categoryFeatures = [];
     private $categoryFeaturesByUrl;
@@ -57,7 +59,8 @@ class FilterHelper
         Request $request,
         Router $router,
         Design $design,
-        Money $money
+        Money $money,
+        FrontTranslations $frontTranslations
     ) {
         $this->entityFactory = $entityFactory;
         $this->request = $request;
@@ -65,6 +68,7 @@ class FilterHelper
         $this->design = $design;
         $this->settings = $settings;
         $this->money = $money;
+        $this->frontTranslations = $frontTranslations;
 
         /** @var LanguagesEntity $languagesEntity */
         $languagesEntity = $entityFactory->get(LanguagesEntity::class);
@@ -526,10 +530,6 @@ class FilterHelper
     
     public function getMetaArray()
     {
-        /** @var TranslationsEntity $translationsEntity */
-        $translationsEntity = $this->entityFactory->get(TranslationsEntity::class);
-        $translations = $translationsEntity->find(['lang' => $this->language->label]); // todo здесь должен быть FrontTranslations
-        
         if ($this->categoryFeatures === null) {
             $this->getCategoryFeatures();
         }
@@ -562,7 +562,7 @@ class FilterHelper
                     {
                         foreach (explode('_', $paramValues) as $f) {
                             if (empty($metaArray['filter'][$f])) {
-                                $metaArray['filter'][$f] = $translations->{"features_filter_" . $f};
+                                $metaArray['filter'][$f] = $this->frontTranslations->getTranslation("features_filter_" . $f);
                             }
                         }
                         break;


### PR DESCRIPTION
### Что PR делает?

В класс FilterHelper подключен класс FrontTranslations и он же используется для получения переводов вместо сущности переводов.

### Зачем PR нужен?

Нужен для того, чтобы устранить критическу ошибку при неправильной работе с переводом