### PR TITLE
Init admintooltip with front user lang

### DIFF
--- a/backend/design/js/admintooltip/admintooltip.php
+++ b/backend/design/js/admintooltip/admintooltip.php
@@ -67,6 +67,7 @@ $backendTranslations->initTranslations($manager->lang);
 $design->assign('btr', $backendTranslations);
 $language = $manager = $DI->get(EntityFactory::class)->get(LanguagesEntity::class)->get((string)$manager->lang);
 $design->assign('language', $language);
+$design->assign('front_lang_id', $_SESSION['lang_id'] ?? (string)$manager->lang->id);
 
 $menuSelector = [];
 $fastMenu = $managerMenu->getFastMenu();

--- a/backend/design/js/admintooltip/tooltip.tpl
+++ b/backend/design/js/admintooltip/tooltip.tpl
@@ -54,7 +54,7 @@ function show_tooltip()
 
     from = encodeURIComponent(window.location);
     tooltipcontent = '';
-    var lang = '&lang_id={$language->id}';
+    var lang = '&lang_id={$front_lang_id}';
     if(typeof  lang_id != 'undefined') {
         lang = '&lang_id=' + lang_id;
     }


### PR DESCRIPTION
### Что PR делает?

Инициализация admintooltip с языком выбраным на фронте, а не языком менеджера.

### Зачем PR нужен?

При быстром редактировании лететь на правильную языковую версию сущности