### PR TITLE
Fixed filter on the catalog page with a selection of multi-properties

### DIFF
--- a/Okay/Entities/ProductsEntity.php
+++ b/Okay/Entities/ProductsEntity.php
@@ -718,7 +718,7 @@ class ProductsEntity extends Entity implements RelatedProductsInterface
                 ->cols(['DISTINCT(pf.product_id)'])
                 ->where('(' . implode(' OR ', $featuresValues) . ')')
                 ->join('LEFT', '__features_values AS fv', 'fv.id=pf.value_id')
-                ->having('COUNT(*) >=' . count($features))
+                ->having('COUNT(DISTINCT fv.feature_id) >=' . count($features))
                 ->groupBy(['product_id']);
 
             $this->select->joinSubSelect(


### PR DESCRIPTION
### Что PR делает?

Мы считаем вхождения товара в фильтре свойств по свойствам, а не их значениям. Важно, чтобы для товара встречалось хотя бы одно значение свойства от каждого выбранного свойства, а не совпадение количества найденых значений с количеством выбранных свойств.

### Зачем PR нужен?

Изменение сделано для того, чтобы решить проблему описанную в [этом](https://github.com/OkayCMS/OkayCMS/pull/40) реквесте, так как указанный реквест её не решает, а создаёт другую(товар должен иметь все выбранные значения в рамках одного свойства, что есть неправильно)