### PR TITLE
Changed iconv encoding to mb_convert_encoding

### DIFF
--- a/backend/Controllers/ImportAdmin.php
+++ b/backend/Controllers/ImportAdmin.php
@@ -149,7 +149,7 @@ class ImportAdmin extends IndexAdmin
 
     private function winToRtf($text) {
         if (function_exists('iconv')) {
-            return @iconv('windows-1251', 'UTF-8', $text);
+            return @mb_convert_encoding($text, 'UTF-8', 'Windows-1251');
         } else {
             $t = '';
             for($i=0, $m=strlen($text); $i<$m; $i++) {

--- a/backend/Controllers/ReportStatsAdmin.php
+++ b/backend/Controllers/ReportStatsAdmin.php
@@ -195,9 +195,10 @@ class ReportStatsAdmin extends IndexAdmin
         fputcsv($f, $total, $columnDelimiter);
         fclose($f);
 
+        mb_substitute_character('');
         file_put_contents(
             $exportFilesDir.$filename,
-            iconv( "utf-8", "windows-1251//IGNORE", file_get_contents($exportFilesDir.$filename))
+            mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')
         );
 
         if ($statCount*$page < $totalCount) {

--- a/backend/Helpers/BackendExportHelper.php
+++ b/backend/Helpers/BackendExportHelper.php
@@ -313,7 +313,13 @@ class BackendExportHelper
         }
 
         $data = ['end' => true, 'page' => $page, 'totalpages' => $totalProducts/$productsCount];
-        file_put_contents($exportFilesDir.$filename, iconv( "utf-8", "windows-1251//IGNORE", file_get_contents($exportFilesDir.$filename)));
+
+        mb_substitute_character('');
+        file_put_contents(
+            $exportFilesDir.$filename,
+            mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')
+        );
+
         return $data;
     }
 

--- a/backend/ajax/export_orders.php
+++ b/backend/ajax/export_orders.php
@@ -109,20 +109,22 @@ if (!empty($orders)) {
         fputcsv($f, $str, $columnDelimiter);
     }
 }
+
+fclose($f);
+
 $totalOrders = $ordersEntity->count($filter);
 
 if($ordersCount*$page < $totalOrders) {
     $data = ['end'=>false, 'page'=>$page, 'totalpages'=>$totalOrders/$ordersCount];
 } else {
     $data = ['end'=>true, 'page'=>$page, 'totalpages'=>$totalOrders/$ordersCount];
+
+    mb_substitute_character('');
+    file_put_contents(
+        $exportFilesDir.$filename,
+        mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')
+    );
 }
-
-fclose($f);
-
-file_put_contents(
-    $exportFilesDir.$filename,
-    iconv( "utf-8", "windows-1251//IGNORE", file_get_contents($exportFilesDir.$filename))
-);
 
 if($data) {
     $response->setContent(json_encode($data), RESPONSE_JSON)->sendContent();

--- a/backend/ajax/export_stat.php
+++ b/backend/ajax/export_stat.php
@@ -123,9 +123,10 @@ $total = [
 fputcsv($f, $total, $columnDelimiter);
 fclose($f);
 
+mb_substitute_character('');
 file_put_contents(
     $exportFilesDir.$filename,
-    iconv( "utf-8", "windows-1251//IGNORE", file_get_contents($exportFilesDir.$filename))
+    mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')
 );
 
 $data = true;

--- a/backend/ajax/export_subscribes.php
+++ b/backend/ajax/export_subscribes.php
@@ -72,20 +72,21 @@ foreach($subscribesEntity->find($filter) as $s) {
     fputcsv($f, $str, $columnDelimiter);
 }
 
+fclose($f);
+
 $totalSubscribes = $subscribesEntity->count();
 
 if($subscribesCount*$page < $totalSubscribes) {
     $data = ['end'=>false, 'page'=>$page, 'totalpages'=>$totalSubscribes/$subscribesCount];
 } else {
     $data = ['end'=>true, 'page'=>$page, 'totalpages'=>$totalSubscribes/$subscribesCount];
+
+    mb_substitute_character('');
+    file_put_contents(
+        $exportFilesDir.$filename,
+        mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')
+    );
 }
-
-fclose($f);
-
-file_put_contents(
-    $exportFilesDir.$filename,
-    iconv( "utf-8", "windows-1251//IGNORE", file_get_contents($exportFilesDir.$filename))
-);
 
 if ($data) {
     $response->setContent(json_encode($data), RESPONSE_JSON)->sendContent();

--- a/backend/ajax/export_users.php
+++ b/backend/ajax/export_users.php
@@ -75,20 +75,21 @@ foreach($usersEntity->find($filter) as $u) {
     fputcsv($f, $str, $columnDelimiter);
 }
 
+fclose($f);
+
 $totalUsers = $usersEntity->count($filter);
 
 if($usersCount*$page < $totalUsers) {
     $data = ['end'=>false, 'page'=>$page, 'totalpages'=>$totalUsers/$usersCount];
 } else {
     $data = ['end'=>true, 'page'=>$page, 'totalpages'=>$totalUsers/$usersCount];
+
+    mb_substitute_character('');
+    file_put_contents(
+        $exportFilesDir.$filename,
+        mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')
+    );
 }
-
-fclose($f);
-
-file_put_contents(
-    $exportFilesDir.$filename,
-    iconv( "utf-8", "windows-1251//IGNORE", file_get_contents($exportFilesDir.$filename))
-);
 
 if ($data) {
     $response->setContent(json_encode($data), RESPONSE_JSON)->sendContent();


### PR DESCRIPTION
### Что PR делает?

Меняет порядок кодировки в экспорте и иморте. Меняет использование iconv на mb_convert_encoding.

### Зачем PR нужен?

Изменение порядка вызова кодирования нужно из-за повторного кодированния одной и той же информации, что приводило к ошибкам.

Использование mb_convert_encoding обусловлено его большей предсказуемостью и меньшей зависимостью от системы на которой выполняется код, а точнее от имплементации библиотеки iconv в системе.