### PR TITLE
Setting NP API request limit to 1000000

### DIFF
--- a/Okay/Modules/OkayCMS/NovaposhtaCost/NovaposhtaCost.php
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/NovaposhtaCost.php
@@ -126,6 +126,7 @@ class NovaposhtaCost
             "calledMethod" => "getCities",
             "methodProperties" => [
                 "Page" => 1,
+                "Limit" => 1000000,
             ],
         ];
         
@@ -215,7 +216,8 @@ class NovaposhtaCost
                 "calledMethod" => "getWarehouses",
                 "methodProperties" => array(
                     "TypeOfWarehouseRef" => $type,
-                    "Page" => 1
+                    "Page" => 1,
+                    "Limit" => 1000000,
                 )
             );
         }


### PR DESCRIPTION
### Что PR делает?

Устанавливает лимит в запросе модуля Новой Почты равному 1000000

### Зачем PR нужен?

До недавнего времени, отсутствие явного указания лимита в запросе означало отсутствие лимита. Теперь же он по-умолчанию равен 500 записям, что ломает логику кода. Чтобы исправить ситуацию, теперь лимит указывается в явном виде.