### PR TITLE
Category base features values should not depend on the products, so t…

### DIFF
--- a/Okay/Helpers/FilterHelper.php
+++ b/Okay/Helpers/FilterHelper.php
@@ -255,8 +255,6 @@ class FilterHelper
 
         /** @var FeaturesValuesEntity $featuresValuesEntity */
         $featuresValuesEntity = $this->entityFactory->get(FeaturesValuesEntity::class);
-        
-        $featuresValuesFilter['visible'] = 1;
 
         // Если скрываем из каталога товары не в наличии, значит и в фильтре их значения тоже не нужны будут
         if ($missingProducts === MISSING_PRODUCTS_HIDE) {


### PR DESCRIPTION
### Что PR делает?

В методе getCategoryBaseFeaturesValues больше не используется фиьтр visible.

### Зачем PR нужен?

При получении базовых значений свойств нужно не зависесть от товаров, которые могут их использовать. Такие товары могут быть, могуть не быть, но значения свойств категории от этого не меняются. В обратном случае возникают ошибки из-за того, что технически значение существует, свойство активно, но у этого значения нет товаров. То есть мы проходим валидацию и не получаем 404, так как значение реальное, но не получаем это значение в списке базовых значений свойств категории.