### PR TITLE
Removed hardcoded db prefix

### DIFF
--- a/backend/Helpers/BackendOrdersHelper.php
+++ b/backend/Helpers/BackendOrdersHelper.php
@@ -626,7 +626,7 @@ class BackendOrdersHelper
         $select ->from(DiscountsEntity::getTable())
                 ->cols(['*'])
                 ->where("((`entity` = 'order' AND `entity_id` = :order_id) OR
-                                (`entity` = 'purchase' AND `entity_id` IN (SELECT `id` FROM `ok_purchases` WHERE `order_id` = :order_id)))")
+                                (`entity` = 'purchase' AND `entity_id` IN (SELECT `id` FROM `".PurchasesEntity::getTable()."` WHERE `order_id` = :order_id)))")
                 ->bindValue('order_id', $orderId);
         $discountIds = $select->results('id');
         if (!empty($discountIds)) {
@@ -698,7 +698,7 @@ class BackendOrdersHelper
         $select ->from(DiscountsEntity::getTable())
             ->cols(['id'])
             ->where("((`entity` = 'order' AND `entity_id` = :order_id) OR
-                            (`entity` = 'purchase' AND `entity_id` IN (SELECT `id` FROM `ok_purchases` WHERE `order_id` = :order_id)))")
+                            (`entity` = 'purchase' AND `entity_id` IN (SELECT `id` FROM `".PurchasesEntity::getTable()."` WHERE `order_id` = :order_id)))")
             ->bindValues(['order_id' => $orderId]);
         if (!empty($discountIds)) {
             $select->where('`id` NOT IN (:discount_ids)')


### PR DESCRIPTION
### Что PR делает?

Убирает жестко прописанные префиксы БД в BackendOrdersHelper

### Зачем PR нужен?

Возникают ошибки когда префикс отличный от дефолтного