### PR TITLE
Fixed assigning novaposhta module id

### DIFF
--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Extenders/BackendExtender.php
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Extenders/BackendExtender.php
@@ -53,7 +53,7 @@ class BackendExtender implements ExtensionInterface
         return $variants;
     }
     
-    public function getDeliveryDataProcedure($delivery, $order)
+    public function getDeliveryDataProcedure($order)
     {
         $moduleId = $this->module->getModuleIdByNamespace(__NAMESPACE__);
         $this->design->assign('novaposhta_module_id', $moduleId);

--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Init/Init.php
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Init/Init.php
@@ -108,7 +108,7 @@ class Init extends AbstractInit
         
         // В админке в заказе достаём данные по доставке
         $this->registerQueueExtension(
-            [BackendOrdersHelper::class, 'findOrderDelivery'],
+            [BackendOrdersHelper::class, 'findOrder'],
             [BackendExtender::class, 'getDeliveryDataProcedure']
         );
 


### PR DESCRIPTION
### Что PR делает?

Исправлено назначение переменной с id модуля новой почты. Если заказ был новый, то расширение не работало.

### Зачем PR нужен?

Неправильная работа полей новой почты при создании нового зазказ в админке.