### PR TITLE
Correction of an error with the Integration1C module

### DIFF
--- a/Okay/Core/Design.php
+++ b/Okay/Core/Design.php
@@ -336,7 +336,6 @@ class Design
     public function useModuleDir()
     {
         $this->useTemplateDir = self::TEMPLATES_MODULE;
-        $this->setSmartyTemplatesDir();
     }
 
     public function isUseModuleDir()

--- a/Okay/Core/Design.php
+++ b/Okay/Core/Design.php
@@ -336,6 +336,7 @@ class Design
     public function useModuleDir()
     {
         $this->useTemplateDir = self::TEMPLATES_MODULE;
+        $this->setSmartyTemplatesDir();
     }
 
     public function isUseModuleDir()

--- a/Okay/Helpers/MainHelper.php
+++ b/Okay/Helpers/MainHelper.php
@@ -493,8 +493,10 @@ class MainHelper
                     $module->getModuleName($route['params']['controller'])
                 );
 
-                $design->setModuleTemplatesDir($moduleTemplateDir);
-                $design->useModuleDir();
+                if (!empty($moduleTemplateDir)) {
+                    $design->setModuleTemplatesDir($moduleTemplateDir);
+                    $design->useModuleDir();
+                }
             }
         }
         return ExtenderFacade::execute(__METHOD__, null, func_get_args());


### PR DESCRIPTION
### Что PR делает?

Исправлена логика, которая приводила к ошибке по причине отсутствия установленной переменной moduleTemplateDir в некоторых модулях (модуль Integration1C)

### Зачем PR нужен?

Ошибка при срабатывании некоторых модулей

### Связанные issue(s)/PR(s)

Сообщите нам, если это связано с issue(s)/PR(s) (см. https://github.blog/2013-05-14-closing-issues-via-pull-requests/)