### PR TITLE
Fixed logic escape admin comment for order history

### DIFF
--- a/backend/Helpers/BackendOrderHistoryHelper.php
+++ b/backend/Helpers/BackendOrderHistoryHelper.php
@@ -735,6 +735,7 @@ class BackendOrderHistoryHelper
             $orderHistory = $this->orderHistoryEntity->find(['order_id' => $orderId]);
 
             foreach ($orderHistory as $item) {
+                $item->text = strip_tags($item->text,'<a><p><b><u><s><strong><i><br><span><div><ol><ul><li><table><tbody><tr><td></td><blockquote>');
                 if ($item->manager_id && isset($managers[$item->manager_id])) {
                     $item->manager_name = $managers[$item->manager_id]->login;
                 }

--- a/backend/design/html/order_history.tpl
+++ b/backend/design/html/order_history.tpl
@@ -78,7 +78,7 @@
                         </div>
                         <div class="boxed boxed--grey">
                             <div class="boxed__content">
-                                {$history_item->text|escape}
+                                {$history_item->text}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Что PR делает?

В истории заказов в комментарии администратора в верстки удалил очистку от тегов.
При сохранении в историю производится очистка от тегов кроме разрешенных.

### Зачем PR нужен?

Необходимо для возможности сохранения админом красивого форматирования своего комментария.
