### PR TITLE
In Feeds module in Google Merchant feed added weight kg in field g:pr…

### DIFF
--- a/Okay/Modules/OkayCMS/Feeds/Core/Presets/Adapters/GoogleMerchantAdapter.php
+++ b/Okay/Modules/OkayCMS/Feeds/Core/Presets/Adapters/GoogleMerchantAdapter.php
@@ -100,7 +100,7 @@ class GoogleMerchantAdapter extends AbstractPresetAdapter
         $result['g:id']['data'] = $this->xmlFeedHelper->escape($product->variant_id);
 
         if (!empty($product->weight > 0)) {
-            $result['g:product_weight']['data'] = $this->xmlFeedHelper->escape($product->weight);
+            $result['g:product_weight']['data'] = $this->xmlFeedHelper->escape($product->weight . ' kg');
         }
 
         if (!empty($product->sku)) {


### PR DESCRIPTION
…oduct_weight

### Что PR делает?

Было добавлена еденица измерения

### Зачем PR нужен?

Для поля g:product_weight была добавлена единица измерения kg без которой была ошибка в feed для Google Merchant
