### PR TITLE
Fixed error related with mb_http_input in filemanager

### DIFF
--- a/backend/design/js/filemanager/config/config.php
+++ b/backend/design/js/filemanager/config/config.php
@@ -13,7 +13,6 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');
-mb_http_input('UTF-8');
 mb_language('uni');
 mb_regex_encoding('UTF-8');
 ob_start('mb_output_handler');


### PR DESCRIPTION
### Что PR делает?

Была удалена лишняя конфигурационная настройка вызывающая в новой версии php 8 ошибку

### Зачем PR нужен?

На php 8  при использовании плагина filemanager в редакторе TinyMCE происходила ошибка из-за mb_http_input метода
