### PR TITLE
Feature/add product category table of content

### DIFF
--- a/1DB_changes/update_4.3.1.sql
+++ b/1DB_changes/update_4.3.1.sql
@@ -1,1 +1,2 @@
 ALTER TABLE `ok_categories` ADD `show_table_content` tinyint(1) NOT NULL DEFAULT '0' AFTER `visible`;
+UPDATE `ok_settings` SET `value` = 'fda37584a5eed426c352a431d4852e01' WHERE `ok_settings`.`param` = 'newpost_key';

--- a/1DB_changes/update_4.3.1.sql
+++ b/1DB_changes/update_4.3.1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `ok_categories` ADD `show_table_content` tinyint(1) NOT NULL DEFAULT '0' AFTER `visible`;

--- a/Okay/Controllers/CategoryController.php
+++ b/Okay/Controllers/CategoryController.php
@@ -68,6 +68,17 @@ class CategoryController extends AbstractController
 
         $productsSort = $catalogHelper->getProductsSort($filtersUrl);
 
+        //  добавляем оглавление в описании категории блога
+        if ($category->show_table_content && !empty($category->description)) {
+            $result = $categoriesHelper->getTableOfContent($category->description);
+            $category->description = $result[0];
+
+            // Выводим оглавление только если там более трех пунктов
+            if (count($result[1]) >= 2) {
+                $this->design->assign('table_of_content', $result[1]);
+            }
+        }
+
         $this->design->assign('category', $category);
         $this->design->assign('sort', $productsSort);
 

--- a/Okay/Entities/CategoriesEntity.php
+++ b/Okay/Entities/CategoriesEntity.php
@@ -22,6 +22,7 @@ class CategoriesEntity extends Entity
         'image',
         'position',
         'visible',
+        'show_table_content',
         'external_id',
         'level_depth',
         'last_modify',

--- a/Okay/Helpers/CategoriesHelper.php
+++ b/Okay/Helpers/CategoriesHelper.php
@@ -5,7 +5,9 @@ namespace Okay\Helpers;
 use Okay\Core\Design;
 use Okay\Core\EntityFactory;
 use Okay\Core\Modules\Extender\ExtenderFacade;
+use Okay\Core\Request;
 use Okay\Core\Settings;
+use Okay\Core\Translit;
 use Okay\Entities\FeaturesEntity;
 use Okay\Entities\FeaturesValuesEntity;
 
@@ -110,5 +112,58 @@ class CategoriesHelper
         }
 
         return ExtenderFacade::execute(__METHOD__, null, func_get_args());
+    }
+
+    /**
+     * Метод генерирует оглавление
+     *
+     * @param $text
+     * @param null $postUrl
+     * @return mixed|void|null
+     */
+    public function getTableOfContent($text, $objectUrl = null)
+    {
+
+        if ($objectUrl === null) {
+            $objectUrl = Request::getRequestUri();
+        }
+
+        $tableOfContent = [];
+        $items = [];
+        preg_match_all("~<([hH]([1-6]))(.*?)>(.*?)</[hH]([1-6])>~", $text, $items);
+
+        if (!empty($items[4])) {
+            $parts = [];
+            foreach ($items[4] as $key=>$string) {
+
+                $sourceHeader = $items[0][$key];
+
+                $id = Translit::translit(strip_tags($string));
+                $id = preg_replace('~^[^a-zA-Z]*(.+?)[^a-zA-Z0-9]*$~', '$1', $id);
+                $anchorUrl = $objectUrl . '#' . $id;
+
+                // формируем массив где ключ оригинальный заголовок (H) значение заголовок со вставленным в него якорем
+                $parts[$sourceHeader] = str_replace($string, '<a id="'.$id.'" href="'.$anchorUrl.'" class="fn_auto_navigation_anchor"></a>'.$string, $sourceHeader);
+
+                // Если у заголовка есть свой клас, добавим наш клас к существующим
+                if (preg_match("~.*?class=['\"](.*?)?['\"].*~", $items[3][$key], $headerAttr)) {
+                    $parts[$sourceHeader] = str_replace($headerAttr[1], "{$headerAttr[1]} fn_auto_navigation_header", $parts[$sourceHeader]);
+                    // Иначе добавляем только наш клас
+                } else {
+                    $parts[$sourceHeader] = str_replace("<{$items[1][$key]}", "<{$items[1][$key]} class=\"fn_auto_navigation_header\"", $parts[$sourceHeader]);
+                }
+
+                $tableOfContentItem['anchor_text']  = strip_tags($string);
+                $tableOfContentItem['anchor_id']    = $id;
+                $tableOfContentItem['url']          = $anchorUrl;
+                $tableOfContentItem['header_level'] = $items[2][$key]; // Уровень заголовка, который поймали
+
+                $tableOfContent[] = $tableOfContentItem;
+            }
+
+            $text = strtr($text, $parts);
+        }
+
+        return ExtenderFacade::execute(__METHOD__, [$text, $tableOfContent], func_get_args());
     }
 }

--- a/backend/Requests/BackendCategoriesRequest.php
+++ b/backend/Requests/BackendCategoriesRequest.php
@@ -24,6 +24,7 @@ class BackendCategoriesRequest
         $category->name             = $this->request->post('name');
         $category->name_h1          = $this->request->post('name_h1');
         $category->visible          = $this->request->post('visible', 'boolean');
+        $category->show_table_content = $this->request->post('show_table_content', 'integer');
         $category->url              = trim($this->request->post('url', 'string'));
         $category->meta_title       = $this->request->post('meta_title');
         $category->meta_keywords    = $this->request->post('meta_keywords');

--- a/backend/design/html/category.tpl
+++ b/backend/design/html/category.tpl
@@ -149,8 +149,6 @@
     </div>
 
     {*Дополнительные настройки*}
-    {$switch_checkboxes = {get_design_block block="category_switch_checkboxes"}}
-    {if !empty($switch_checkboxes)}
     <div class="row">
         <div class="col-lg-12 col-md-12">
             <div class="boxed fn_toggle_wrap ">
@@ -162,13 +160,22 @@
                 </div>
                 <div class="toggle_body_wrap on fn_card">
                     <div class="activity_of_switch activity_of_switch--box_settings">
-                        {$switch_checkboxes}
+                        <div class="activity_of_switch_item"> {* row block *}
+                            <div class="okay_switch clearfix">
+                                <label class="switch_label">{$btr->general_show_table_content|escape}</label>
+                                <label class="switch switch-default">
+                                    <input class="switch-input" name="show_table_content" value='1' type="checkbox" {if $category->show_table_content}checked=""{/if}/>
+                                    <span class="switch-label"></span>
+                                    <span class="switch-handle"></span>
+                                </label>
+                            </div>
+                        </div>
+                        {get_design_block block="category_switch_checkboxes"}
                     </div>
                 </div>
             </div>
         </div>
     </div>
-    {/if}
 
     {*Параметры элемента*}
     <div class="row">

--- a/design/okay_shop/html/products.tpl
+++ b/design/okay_shop/html/products.tpl
@@ -98,10 +98,21 @@
 
             {if $description}
                 <div class="boxed boxed--big">
-                    <div class="">
-                        <div class="fn_readmore">
-                            <div class="block__description">{$description}</div>
+                    {* Table contents *}
+                    {if !empty($table_of_content)}
+                        <div class="post__table_contents">
+                            <div class="post__table_contents_title">{$lang->blog_table_contents}</div>
+                            <ol>
+                                {foreach $table_of_content as $content_item}
+                                    <li style="margin-left: {$content_item.header_level*15-15}px">
+                                        <a class="fn_ancor_post" href="{$content_item.url|escape}">{$content_item.anchor_text|escape}</a>
+                                    </li>
+                                {/foreach}
+                            </ol>
                         </div>
+                    {/if}
+                    <div class="">
+                        <div class="block__description">{$description}</div>
                     </div>
                 </div>
             {/if}


### PR DESCRIPTION
Что PR делает?
Добавлено автоматическое создание оглавление для категорий. Если в полном описании есть теги h1-h6 то из них создастся содержание полного описания и выводится над полным описанием. Показывается при условии что таких ссылок было найдено 2 и больше. А также при условии что у данной категории активировано в настройках показ оглавления.

Зачем PR нужен?
Новый функционал оглавлений для быстрого перехода
