### PR TITLE
Fixed error in Default strategy in Brand when empty settings

### DIFF
--- a/Okay/Core/Routes/Strategies/Brand/DefaultStrategy.php
+++ b/Okay/Core/Routes/Strategies/Brand/DefaultStrategy.php
@@ -32,8 +32,12 @@ class DefaultStrategy extends AbstractRouteStrategy
 
         $this->brandsEntity = $entityFactory->get(BrandsEntity::class);
 
+        if (empty($prefix = $this->settings->get('brand_routes_template__default'))) {
+            $prefix = 'brand';
+        }
+
         $this->mockRouteParams = [
-            '/'.$this->settings->get('brand_routes_template__default').'/{$url}/?{$filtersUrl}', [
+            '/'.$prefix.'/{$url}/?{$filtersUrl}', [
                 '{$url}' => ' ', '{$filtersUrl}' => '(.*)'
             ],
             []


### PR DESCRIPTION
### Что PR делает?

Была доработана логика при пустом значении префикса, добавляется статическая часть в таком случае.

### Зачем PR нужен?

Если не была сохранена настройка префикса (brand_routes_template__default) в БД тогда адрес страницы бренда формировался неправильно (на странице всех брендов и в админке в карточке бренда неправильная ссылка)