### PR TITLE
Fixing the connection location when smtp sending mail to PHPMailer

### DIFF
--- a/Okay/Core/Notify.php
+++ b/Okay/Core/Notify.php
@@ -120,7 +120,7 @@ class Notify
             $this->PHPMailer->AddAddress($to);
         }
         
-        $this->PHPMailer = ExtenderFacade::execute(__FUNCTION__, $this->PHPMailer, func_get_args());
+        $this->PHPMailer = ExtenderFacade::execute(__METHOD__, $this->PHPMailer, func_get_args());
         
         $success = $this->PHPMailer->Send();
 


### PR DESCRIPTION
### Что PR делает?

Заменено на имя метода для привязки при помощи ExtenderFacade

### Зачем PR нужен?

Теперь возможно корректно перехватывать и модифицировать объект при отправки почты PHPMailer
