### PR TITLE
Fixing logic, no include js and css files module for unactive modules

### DIFF
--- a/Okay/Core/TemplateConfig/FrontTemplateConfig.php
+++ b/Okay/Core/TemplateConfig/FrontTemplateConfig.php
@@ -591,6 +591,11 @@ class FrontTemplateConfig
         $runningModules = $this->modules->getRunningModules();
         foreach ($runningModules as $runningModule) {
 
+            //  пропускаем не активированные модули
+            if (empty($runningModule['is_active'])) {
+                continue;
+            }
+
             $moduleThemesDir = $this->module->getModuleDirectory($runningModule['vendor'], $runningModule['module_name']) . 'design/';
 
             if (file_exists($moduleThemesDir . 'css.php') && ($moduleCss = include $moduleThemesDir . 'css.php') && is_array($moduleCss)) {


### PR DESCRIPTION
### Что PR делает?

Пропускает шаг итареции подключения ресурсов (js, css) для модулей которые не активны

### Зачем PR нужен?

Не подключаются лишние ресурсы для не активных модулей