### PR TITLE
Remove wrong .pl-0 & .pr-0 override

### DIFF
--- a/backend/design/css/media.css
+++ b/backend/design/css/media.css
@@ -152,8 +152,6 @@
     }
 }
 @media only screen and (max-width : 991px) {
-    .pr-0 {padding-right: 15px !important;}
-    .pl-0{padding-left: 15px !important;}
     .boxed_search{padding: 0px 0px 20px;}
     .product_images_list li{height: 140px;width: 140px;line-height: 140px;}
     .variants_listadd{min-width: 900px;}


### PR DESCRIPTION
Стилі що відповідають за нульовий padding справа і зліва робили padding 15px, можливо передбачалося компенсування margin-left -15px але фактично ніде не використовувалося і працювало некоректно