### PR TITLE
Bugfix/flickering block new variant

### DIFF
--- a/backend/design/html/product.tpl
+++ b/backend/design/html/product.tpl
@@ -384,7 +384,7 @@
                                     {/if}
                                 </div>
                             {/foreach}
-                            <div class="okay_list_body_item variants_list_item fn_new_row_variant">
+                            <div class="okay_list_body_item variants_list_item fn_new_row_variant hidden">
                                 <div class="okay_list_row ">
                                     <div class="okay_list_boding variants_item_drag">
                                         <div class="heading_label"></div>
@@ -500,7 +500,7 @@
                                 </li>
                             {/foreach}
                         {/if}
-                        <li class="fn_new_spec_image_item product_image_item fn_sort_item">
+                        <li class="fn_new_spec_image_item product_image_item fn_sort_item hidden">
                             <button type="button" class="fn_remove_image remove_image"></button>
                             <img src="" alt=""/>
                             <i class="move_zone fa fa-arrows font-2xl"></i>
@@ -804,7 +804,7 @@
 
         var image_item_clone = $(".fn_new_image_item").clone(true).removeClass('hidden');
         $(".fn_new_image_item").remove();
-        var new_image_tem_clone = $(".fn_new_spec_image_item").clone(true);
+        var new_image_tem_clone = $(".fn_new_spec_image_item").clone(true).removeClass('hidden');
         $(".fn_new_spec_image_item").remove();
         // Или перетаскиванием
         if(window.File && window.FileReader && window.FileList) {
@@ -889,7 +889,7 @@
         });
 
         // Добавление варианта
-        var variant = $(".fn_new_row_variant").clone(false);
+        var variant = $(".fn_new_row_variant").clone(false).removeClass('hidden');
         $(".fn_new_row_variant").remove();
         variant.find('.bootstrap-select').replaceWith(function() { return $('select', this); });
         $(document).on("click", ".fn_add_variant", function () {


### PR DESCRIPTION
### Что PR делает?

В верстке в карточке товара в административной панели были скрыты элементы новых блоков для варианта и промо-изображения т.к. они вызывали мерцание при обновлении страницы т.к. потом скрывались JS

### Зачем PR нужен?

Не происходит мерцания/смещение контента, более дружественный UI в карточке товара
