### PR TITLE
Allow single column placeholder value bind

### DIFF
--- a/Okay/Core/QueryFactory/Update.php
+++ b/Okay/Core/QueryFactory/Update.php
@@ -39,7 +39,7 @@ class Update extends AbstractQuery implements QueryInterface
 
     public function col($col)
     {
-        $this->queryObject->col($col);
+        $this->queryObject->col(...func_get_args());
         return $this;
     }
 


### PR DESCRIPTION
Аналогично `Update->cols` escape'ит значение для колонки, без `...func_get_args()` второй параметр не передаётся

> Sets one column value placeholder; if an optional second parameter is passed, that value is bound to the placeholder.