### PR TITLE
Fixed config name library var-dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "dragonmantank/cron-expression": "^3.1",
         "symfony/process": "^5.3",
         "symfony/lock": "^5.3",
-        "symfony/vardumper": "^5.4.6"
+        "symfony/var-dumper": "^5.4.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
### Что PR делает?

В файле composer.json немного исправили название библиотеки с symfony/vardumper на symfony/va-rdumper

### Зачем PR нужен?

Некритичная правка на значение указанное в документации