### PR TITLE
Fixed mb_substitute_character function for PHP 8

### DIFF
--- a/backend/Controllers/ReportStatsAdmin.php
+++ b/backend/Controllers/ReportStatsAdmin.php
@@ -195,7 +195,7 @@ class ReportStatsAdmin extends IndexAdmin
         fputcsv($f, $total, $columnDelimiter);
         fclose($f);
 
-        mb_substitute_character('');
+        mb_substitute_character('none');
         file_put_contents(
             $exportFilesDir.$filename,
             mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')

--- a/backend/Helpers/BackendExportHelper.php
+++ b/backend/Helpers/BackendExportHelper.php
@@ -314,7 +314,7 @@ class BackendExportHelper
 
         $data = ['end' => true, 'page' => $page, 'totalpages' => $totalProducts/$productsCount];
 
-        mb_substitute_character('');
+        mb_substitute_character('none');
         file_put_contents(
             $exportFilesDir.$filename,
             mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')

--- a/backend/ajax/export_orders.php
+++ b/backend/ajax/export_orders.php
@@ -119,7 +119,7 @@ if($ordersCount*$page < $totalOrders) {
 } else {
     $data = ['end'=>true, 'page'=>$page, 'totalpages'=>$totalOrders/$ordersCount];
 
-    mb_substitute_character('');
+    mb_substitute_character('none');
     file_put_contents(
         $exportFilesDir.$filename,
         mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')

--- a/backend/ajax/export_stat.php
+++ b/backend/ajax/export_stat.php
@@ -16,9 +16,9 @@ $totalPrice  = 0;
 $totalAmount = 0;
 
 $columnsNames = [
-    'name'   => '���',
-    'amount' => '����������',
-    'price'  => '����',
+    'name'   => 'Имя',
+    'amount' => 'Количество',
+    'price'  => 'Цена',
 ];
 
 $columnDelimiter = ';';
@@ -54,20 +54,20 @@ if (!$managers->access('category_stats', $managersEntity->get($_SESSION['admin']
     exit();
 }
 
-// ��������, ������� ������������
+// Страница, которую экспортируем
 $page = $request->get('page');
 if (empty($page) || $page==1) {
     $page = 1;
-    // ���� ������ ������� - ������ ������ ���� ��������
+    // Если начали сначала - удалим старый файл экспорта
     if (is_writable($exportFilesDir.$filename)) {
         unlink($exportFilesDir.$filename);
     }
 }
 
-// ��������� ���� �������� �� ����������
+// Открываем файл экспорта на добавление
 $f = fopen($exportFilesDir.$filename, 'ab');
 
-// ���� ������ ������� - ������� � ������ ������ �������� �������
+// Если начали сначала - добавим в первую строку названия колонок
 if ($page == 1) {
     fputcsv($f, $columnsNames, $columnDelimiter);
 }
@@ -115,7 +115,7 @@ foreach ($categories_list as $c) {
 }
 
 $total = [
-    'name' => '���',
+    'name' => 'Имя',
     'amount' => $totalAmount,
     'price'=>$totalPrice
 ];

--- a/backend/ajax/export_stat.php
+++ b/backend/ajax/export_stat.php
@@ -16,9 +16,9 @@ $totalPrice  = 0;
 $totalAmount = 0;
 
 $columnsNames = [
-    'name'   => 'Имя',
-    'amount' => 'Количество',
-    'price'  => 'Цена',
+    'name'   => 'пїЅпїЅпїЅ',
+    'amount' => 'пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ',
+    'price'  => 'пїЅпїЅпїЅпїЅ',
 ];
 
 $columnDelimiter = ';';
@@ -54,20 +54,20 @@ if (!$managers->access('category_stats', $managersEntity->get($_SESSION['admin']
     exit();
 }
 
-// Страница, которую экспортируем
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 $page = $request->get('page');
 if (empty($page) || $page==1) {
     $page = 1;
-    // Если начали сначала - удалим старый файл экспорта
+    // пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ - пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
     if (is_writable($exportFilesDir.$filename)) {
         unlink($exportFilesDir.$filename);
     }
 }
 
-// Открываем файл экспорта на добавление
+// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 $f = fopen($exportFilesDir.$filename, 'ab');
 
-// Если начали сначала - добавим в первую строку названия колонок
+// пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ - пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 if ($page == 1) {
     fputcsv($f, $columnsNames, $columnDelimiter);
 }
@@ -115,7 +115,7 @@ foreach ($categories_list as $c) {
 }
 
 $total = [
-    'name' => 'Имя',
+    'name' => 'пїЅпїЅпїЅ',
     'amount' => $totalAmount,
     'price'=>$totalPrice
 ];
@@ -123,7 +123,7 @@ $total = [
 fputcsv($f, $total, $columnDelimiter);
 fclose($f);
 
-mb_substitute_character('');
+mb_substitute_character('none');
 file_put_contents(
     $exportFilesDir.$filename,
     mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')

--- a/backend/ajax/export_subscribes.php
+++ b/backend/ajax/export_subscribes.php
@@ -81,7 +81,7 @@ if($subscribesCount*$page < $totalSubscribes) {
 } else {
     $data = ['end'=>true, 'page'=>$page, 'totalpages'=>$totalSubscribes/$subscribesCount];
 
-    mb_substitute_character('');
+    mb_substitute_character('none');
     file_put_contents(
         $exportFilesDir.$filename,
         mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')

--- a/backend/ajax/export_users.php
+++ b/backend/ajax/export_users.php
@@ -84,7 +84,7 @@ if($usersCount*$page < $totalUsers) {
 } else {
     $data = ['end'=>true, 'page'=>$page, 'totalpages'=>$totalUsers/$usersCount];
 
-    mb_substitute_character('');
+    mb_substitute_character('none');
     file_put_contents(
         $exportFilesDir.$filename,
         mb_convert_encoding(file_get_contents($exportFilesDir.$filename), 'Windows-1251')


### PR DESCRIPTION
### Что PR делает?

Переконфигурирован метод mb_substitute_character в helper экспорта

### Зачем PR нужен?

Метод используется при экспорте, устарел и вызывал критическую ошибку на PHP выше 8 версии