### PR TITLE
Set for feature entity default value = 0 for field show_in_product

### DIFF
--- a/backend/Requests/BackendFeaturesRequest.php
+++ b/backend/Requests/BackendFeaturesRequest.php
@@ -41,7 +41,7 @@ class BackendFeaturesRequest
         $feature->visible            = $this->request->post('visible', 'int');
         $feature->to_index_new_value = $this->request->post('to_index_new_value');
         $feature->description        = $this->request->post('description');
-        $feature->show_in_product    = $this->request->post('show_in_product');
+        $feature->show_in_product    = $this->request->post('show_in_product', 'int', 0);
 
         $feature->url = preg_replace("/[\s]+/ui", '', $feature->url);
         $feature->url = strtolower(preg_replace("/[^0-9a-z]+/ui", '', $feature->url));


### PR DESCRIPTION
### Что PR делает?

При сохранении свойства в админ-панели если галочка отключена присваивает значение по умолчанию = 0 

### Зачем PR нужен?

Из-за особенностей checkbox при отключенном элементе checkbox у show_in_product в новое свойство попадало null что приводило в ошибке записи в БД
