### PR TITLE
Take into account the pre-order setting when issuing options that are…

### DIFF
--- a/Okay/Entities/VariantsEntity.php
+++ b/Okay/Entities/VariantsEntity.php
@@ -126,7 +126,9 @@ class VariantsEntity extends Entity
 
     protected function filter__in_stock()
     {
-        $this->select->where('(v.stock > 0 OR v.stock IS NULL)');
+        if (empty($this->settings->get('is_preorder')) || ($this->settings->get('is_preorder') != 1)) {
+            $this->select->where('(v.stock > 0 OR v.stock IS NULL)');
+        }
     }
 
     protected function filter__not_id($id)


### PR DESCRIPTION
… not in stock

### Что PR делает?

При включенной настройки Предзаказ отсутствующих товаров у сущности вариантов не срабатывает логика проверки наличия варианта на складе, т.к. необходимо все варианты даже с кол-вом равным 0

### Зачем PR нужен?

Выборка по количеству на складе теперь учитывает настройку предзаказа
