### PR TITLE
Fixed slash in end url in all-posts route

### DIFF
--- a/Okay/Core/Routes/RouteFactory.php
+++ b/Okay/Core/Routes/RouteFactory.php
@@ -28,6 +28,10 @@ class RouteFactory
             return new BlogCategoryRoute($params);
         }
 
+        if ($routeName === 'blog') {
+            return new AllBlogRoute($params);
+        }
+
         if ($routeName === 'post') {
             return new PostRoute($params);
         }


### PR DESCRIPTION
### Что PR делает?

Добавляет связь к роутеру для all-posts, роут blog

### Зачем PR нужен?

Правка позволяет теперь корректно срабатывать логике добавления в конце адреса слеша если такая настройка активирована