### PR TITLE
Fix resource-intensive products count query in FeaturesAdmin

### DIFF
--- a/backend/design/html/features.tpl
+++ b/backend/design/html/features.tpl
@@ -143,11 +143,7 @@
                             <div class="okay_list_boding feature_value_products_num">
                                 <div class="heading_label visible_md">{$btr->feature_value_products_num}</div>
                                 <a href="{$rootUrl}/backend/index.php?controller=ProductsAdmin&feature_id={$feature->id}" class="form-control" target="_blank">
-                                    {if isset($products_counts[$feature->id])}
-                                        {$products_counts[$feature->id]}
-                                    {else}
-                                        0
-                                    {/if}
+                                    {$products_counts[$feature->id]|default:0}
                                 </a>
                             </div>
 

--- a/backend/design/html/features.tpl
+++ b/backend/design/html/features.tpl
@@ -143,8 +143,8 @@
                             <div class="okay_list_boding feature_value_products_num">
                                 <div class="heading_label visible_md">{$btr->feature_value_products_num}</div>
                                 <a href="{$rootUrl}/backend/index.php?controller=ProductsAdmin&feature_id={$feature->id}" class="form-control" target="_blank">
-                                    {if isset($products_counts[$feature->id]['count'])}
-                                        {$products_counts[$feature->id]['count']}
+                                    {if isset($products_counts[$feature->id])}
+                                        {$products_counts[$feature->id]}
                                     {else}
                                         0
                                     {/if}


### PR DESCRIPTION
Запрашивались ВСЕ свойства, ВСЕ их значения со всеми колонками, и только для того, чтобы для каждого значения посчитать количество товаров и просуммировать их. Не использовался фильтр свойств, передаваемый в метод (обычно первые 25, на первой странице). Это создавало огромную нагрузку на сервер, так как ВСЕ значения ВСЕХ свойств занимали около 4 Гб оперативки.