### PR TITLE
Core\Settings formatting and null value handling

### DIFF
--- a/Okay/Core/Settings.php
+++ b/Okay/Core/Settings.php
@@ -4,31 +4,26 @@
 namespace Okay\Core;
 
 
+use Okay\Entities\LanguagesEntity;
+
 /**
  * Управление настройками магазина, хранящимися в базе данных
  * В отличие от класса Config оперирует настройками доступными админу и хранящимися в базе данных.
  */
 class Settings
 {
-    
     private $vars;
     private $vars_lang;
     
-    /**
-     * @var Database
-     */
+    /** @var Database */
     private $db;
-
-    /**
-     * @var Languages
-     */
+    
+    /** @var Languages */
     private $languages;
-
-    /**
-     * @var QueryFactory
-     */
+    
+    /** @var QueryFactory */
     private $queryFactory;
-
+    
     public function __construct(Database $db, Languages $languages, QueryFactory $queryFactory)
     {
         $this->db = $db;
@@ -37,53 +32,44 @@ class Settings
         $this->initSettings();
     }
     
-    public function get($param)
+    public function has(string $param): bool
     {
-        if (isset($this->vars_lang[$param])) {
-            return $this->vars_lang[$param];
-        } elseif (isset($this->vars[$param])) {
-            return $this->vars[$param];
-        } else {
-            return null;
-        }
+        return array_key_exists($param, $this->vars_lang) || array_key_exists($param, $this->vars);
     }
     
-    public function has($param)
+    public function get(string $param)
     {
-        return isset($this->vars_lang[$param]) || isset($this->vars[$param]);
+        return $this->vars_lang[$param] ?? $this->vars[$param] ?? null;
     }
     
-    public function set($param, $value)
+    /** Запись данных в общие настройки */
+    public function set(string $param, $value): void
     {
-        if (isset($this->vars_lang[$param])) {
+        if (array_key_exists($param, $this->vars_lang)) {
             return;
         }
         
-        if(is_array($value)) {
+        if (is_array($value)) {
             $valuePrepared = serialize($value);
         } else {
-            $valuePrepared = (string) $value;
+            $valuePrepared = (string)$value;
         }
         
-        if(!isset($this->vars[$param])) {
-            $insert = $this->queryFactory->newInsert();
-            $insert->into('__settings')
+        if (!array_key_exists($param, $this->vars)) {
+            $this->queryFactory->newInsert()
+                ->into('__settings')
                 ->cols([
                     'value' => $valuePrepared,
                     'param' => $param,
-                ]);
-
-            $this->db->query($insert);
+                ])->execute();
         } elseif ($this->vars[$param] != $value) {
-            $update = $this->queryFactory->newUpdate();
-            $update->table('__settings')
+            $this->queryFactory->newUpdate()
+                ->table('__settings')
                 ->cols(['value' => $valuePrepared])
-                ->where('param = :param');
-            $update->bindValue('param', $param);
-
-            $this->db->query($update);
+                ->where('param = ?', $param)
+                ->execute();
         }
-
+        
         $this->vars[$param] = $value;
     }
     
@@ -91,26 +77,26 @@ class Settings
     {
         return $this->get($param);
     }
-
-    /*Запись данных в общие настройки*/
-    public function __set($param, $value)
+    
+    public function __set($param, $value): void
     {
         $this->set($param, $value);
     }
-
-    /*Выборка всех данных с таблиц настроек*/
-    public function initSettings()
+    
+    /** Выборка всех данных из таблиц настроек */
+    public function initSettings(): void
     {
         // Выбираем из базы ОБЩИЕ настройки и записываем их в переменную
         $this->vars = [];
         
-        $select = $this->queryFactory->newSelect();
-        
-        $this->db->query($select->cols(['param', 'value'])->from('__settings'));
-        foreach($this->db->results() as $result) {
-            $this->vars[$result->param] = $this->unserialize($result->value, $result->value);;
+        $settings = $this->queryFactory->newSelect()
+            ->cols(['param', 'value'])
+            ->from('__settings')
+            ->results();
+        foreach ($settings as $s) {
+            $this->vars[$s->param] = $this->unserialize($s->value, $s->value);
         }
-
+        
         // Выбираем из базы настройки с переводами к текущему языку
         $this->vars_lang = [];
         $multi = $this->getSettings();
@@ -120,16 +106,22 @@ class Settings
             }
         }
     }
-
-    private function unserialize($value, $default = false)
+    
+    /**
+     * If $data is unserializeable, returns the value, otherwise, returns $default
+     * @param string $data
+     * @param mixed $default
+     * @return mixed
+     */
+    private function unserialize(string $data, $default = false)
     {
-        $success = true;
-        set_error_handler(function () use (&$success) {
-            $success = false;
+        $unserializeable = true;
+        set_error_handler(function () use (&$unserializeable) {
+            $unserializeable = false;
         });
-        $original = unserialize($value);
+        $value = unserialize($data);
         restore_error_handler();
-        return $success ? $original : $default;
+        return $unserializeable ? $value : $default;
     }
     
     /**
@@ -139,47 +131,38 @@ class Settings
      * @return bool
      * @throws \Exception
      */
-    private function add($param, $value)
+    private function add(string $param, string $value): bool
     {
-        $select = $this->queryFactory->newSelect();
-        $select->from(\Okay\Entities\LanguagesEntity::getTable())
-            ->cols(['id']);
-        $this->db->query($select);
-        $languagesIds = $this->db->results('id');
+        $languagesIds = $this->queryFactory->newSelect()
+            ->cols(['id'])
+            ->from(LanguagesEntity::getTable())
+            ->results('id');
         
-        if (!empty($languagesIds)) {
-            foreach ($languagesIds as $lId) {
-
-                $delete = $this->queryFactory->newDelete();
-                $delete->from('__settings_lang')
-                    ->where('param =:param')
-                    ->where('lang_id =:lang_id')
-                    ->bindValue('param', $param)
-                    ->bindValue('lang_id', $lId);
-
-                $this->db->query($delete);
+        if ($languagesIds) {
+            foreach ($languagesIds as $langId) {
                 
-                $insert = $this->queryFactory->newInsert();
-                $insert->into('__settings_lang')
+                $this->queryFactory->newDelete()
+                    ->from('__settings_lang')
+                    ->where('param = ?', $param)
+                    ->where('lang_id = ?', $langId)
+                    ->execute();
+                
+                $this->queryFactory->newInsert()
+                    ->into('__settings_lang')
                     ->cols([
                         'param' => $param,
                         'value' => $value,
-                        'lang_id' => $lId,
-                    ]);
-
-                $this->db->query($insert);
-                
+                        'lang_id' => $langId,
+                    ])->execute();
             }
         } else {
-            $delete = $this->queryFactory->newDelete();
-            $delete->from('__settings_lang')
-                ->where('param =:param')
-                ->bindValue('param', $param);
+            $this->queryFactory->newDelete()
+                ->from('__settings_lang')
+                ->where('param = ?', $param)
+                ->execute();
 
-            $this->db->query($delete);
-
-            $insert = $this->queryFactory->newInsert();
-            $insert->into('__settings_lang')
+            $insert = $this->queryFactory->newInsert()
+                ->into('__settings_lang')
                 ->cols([
                     'param' => $param,
                     'value' => $value,
@@ -191,92 +174,87 @@ class Settings
         }
         return true;
     }
-
+    
     /**
-     * Updating by $param(current language), or adding;
-     * if a setting with specified $param is exist - it will be updated,
-     * otherwise it will be added(called add() function).
+     * Updating by $param (current language), or adding;
+     * if a setting with specified $param exists - it will be updated,
+     * otherwise, it will be added(add() function will be called).
      * @param string $param
-     * @param string $value
+     * @param string|array $value
      * @return bool
      * @throws \Exception
      */
-    public function update($param, $value)
+    public function update(string $param, $value): bool
     {
         if (empty($param)) {
             return false;
         }
         $this->vars_lang[$param] = $value;
-        $value = is_array($value) ? serialize($value) : (string) $value;
-
-        $select = $this->queryFactory->newSelect();
-        $select->from('__settings_lang')
+        $value = is_array($value) ? serialize($value) : (string)$value;
+        
+        $select = $this->queryFactory->newSelect()
             ->cols(['1'])
-            ->where('param = :param')
-            ->bindValue('param', $param)
+            ->from('__settings_lang')
+            ->where('param = ?', $param)
             ->limit(1);
         
-        $this->db->query($select);
-        if (!$this->db->result()) {
+        if (!$select->result()) {
             return $this->add($param, $value);
         } else {
-            $delete = $this->queryFactory->newDelete();
-            $delete->from('__settings_lang')
-                ->where('param =:param')
-                ->bindValue('param', $param);
-                
-            $insert = $this->queryFactory->newInsert();
-            $insert->into('__settings_lang')
+            $delete = $this->queryFactory->newDelete()
+                ->from('__settings_lang')
+                ->where('param = ?', $param);
+            
+            $insert = $this->queryFactory->newInsert()
+                ->into('__settings_lang')
                 ->cols([
                     'param' => $param,
                     'value' => $value,
                 ]);
-
+            
             if ($langId = $this->languages->getLangId()) {
-                $delete->where('lang_id =:lang_id')
-                    ->bindValue('lang_id', $langId);
+                $delete->where('lang_id = ?', $langId);
                 $insert->cols(['lang_id' => $langId]);
             }
-
-            $this->db->query($delete);
-            $this->db->query($insert);
+            
+            $delete->execute();
+            $insert->execute();
             
             return true;
         }
     }
-
+    
     /**
      * Getting settings.
-     * if $langId is not specified, a current language will be returned.
-     * $langId = 0 is wrong, will be returned false.
-     * @param int $langId
-     * @return array|bool
+     * If $langId is not specified, the current language will be used.
+     * $langId = 0 is wrong, false will be returned.
+     * @param int|null $langId
+     * @return array|false
      * @throws \Exception
      */
-    public function getSettings($langId = null)
+    public function getSettings(?int $langId = null)
     {
-        $select = $this->queryFactory->newSelect();
-        $select->from(\Okay\Entities\LanguagesEntity::getTable())
-            ->cols(['id'])
-            ->where("id=" . (int)$langId)
-            ->limit(1);
-        $this->db->query($select);
+        $langExists = $this->queryFactory->newSelect()
+            ->cols(['1'])
+            ->from(LanguagesEntity::getTable())
+            ->where('id = ?', $langId)
+            ->limit(1)
+            ->result();
         
-        if (!is_null($langId) && !$this->db->results('id')) {
+        if (!is_null($langId) && !$langExists) {
             return false;
         }
-
-        $select = $this->queryFactory->newSelect();
-        $select->from('__settings_lang')
-            ->cols(['*']);
         
-        $langId  = !is_null($langId) ? $langId : $this->languages->getLangId();
-        if($langId) {
-            $select->where('lang_id=:action_object_lang_id');
-            $select->bindValues(['action_object_lang_id'=>$langId]);
+        $select = $this->queryFactory->newSelect()
+            ->cols(['*'])
+            ->from('__settings_lang');
+        
+        $langId = $langId ?? $this->languages->getLangId();
+        if ($langId) {
+            $select->where('lang_id = :action_object_lang_id');
+            $select->bindValues(['action_object_lang_id' => $langId]);
         }
-        $this->db->query($select);
-        return $this->db->results();
+        return $select->results();
     }
-
+    
 }

--- a/Okay/Core/Settings.php
+++ b/Okay/Core/Settings.php
@@ -113,15 +113,15 @@ class Settings
      * @param mixed $default
      * @return mixed
      */
-    private function unserialize(string $data, $default = false)
+    private function unserialize($in, $default)
     {
-        $unserializeable = true;
-        set_error_handler(function () use (&$unserializeable) {
-            $unserializeable = false;
+        if ($in === '') return $default;
+        set_error_handler(function () use (&$out, $default) {
+            $out = $default;
         });
-        $value = unserialize($data);
+        $out = unserialize($in);
         restore_error_handler();
-        return $unserializeable ? $value : $default;
+        return $out;
     }
     
     /**


### PR DESCRIPTION
- Добавление type hints
- Использование Okay\AbstractQuery::execute, result и results вместо Okay\Database по возможности
- Inline-placeholders `->where('param = ?', $param)` вместо `->where('param = :param')->bindValue('param', $param)`
- Обработка случая, который выдавал ошибку `duplicate entry for key 'param'`:
  ```php
  $settings->set($param, null);
  $settings->set($param, 'abc');
  ```
  Причиной был следующий фрагмент, который считал, что настройки нет, и пытался её создать (`insert`), если ей присваивали `null`, а на самом деле `null` конвертировался в пустую строку (`''`):
  https://github.com/OkayCMS/OkayCMS/blob/1b342b7743bfd4c92dd50e5b6972b1f862658cb2/Okay/Core/Settings.php#L68-L78