### PR TITLE
Fixed callback url in WayForPay module

### DIFF
--- a/Okay/Modules/OkayCMS/WayForPay/Init/routes.php
+++ b/Okay/Modules/OkayCMS/WayForPay/Init/routes.php
@@ -4,7 +4,7 @@ namespace Okay\Modules\OkayCMS\WayForPay;
 
 return [
     'OkayCMS_WayForPay_callback' => [
-        'slug' => 'payment/OkayCMS/WayForPay/callback',
+        'slug' => 'payment/okaycms/wayforpay/callback',
         'params' => [
             'controller' => __NAMESPACE__ . '\Controllers\CallbackController',
             'method' => 'payOrder',


### PR DESCRIPTION
### Что PR делает?

Изменен url callback контроллера в модуле WayForPay

### Зачем PR нужен?

Некоторые хостинги не любят заглавные буквы в url, для callback в модуле WayForPay был заменен на все строчные символы
