### PR TITLE
add features to google merchant feed

### DIFF
--- a/Okay/Modules/OkayCMS/Feeds/Core/Presets/Adapters/GoogleMerchantAdapter.php
+++ b/Okay/Modules/OkayCMS/Feeds/Core/Presets/Adapters/GoogleMerchantAdapter.php
@@ -155,6 +155,36 @@ class GoogleMerchantAdapter extends AbstractPresetAdapter
 
         $result['g:adult']['data'] = $this->feed->settings['adult'] ? 'true' : 'false';
 
+        //добавляем атрибуты в product_detail, согласно настройкам в ok_okay_cms__feeds__feeds
+        if (isset($product->features)) {
+            foreach ($product->features as $keyFeature => $feature) {
+                $attributeName = $this->xmlFeedHelper->escape($feature['name']);
+                $attributeValue = $this->xmlFeedHelper->escape($feature['values_string']);
+                if (isset($this->feed->features_settings[$feature['id']]['name_in_feed']) && $this->feed->features_settings[$feature['id']]['name_in_feed']) {
+                    $attributeName = $this->xmlFeedHelper->escape($this->feed->features_settings[$feature['id']]['name_in_feed']);
+                }
+                if (isset($attributeName) && $attributeName
+                    && isset($attributeValue) && $attributeValue
+                    && (!isset($this->feed->features_settings[$feature['id']])  //показываем свойство, если под него нет вообще настроек
+                        || $this->feed->features_settings[$feature['id']]['to_feed']
+                    )
+                ) {
+                    $result[] = [
+                        'tag' => 'g:product_detail',
+                        'data' => [
+                            'g:attribute_name' => [
+                                'data' => $attributeName
+                            ],
+                            'g:attribute_value' => [
+                                'data' => $attributeValue
+                            ],
+                        ]
+                    ];
+                }
+            }
+        }
+        ///добавляем атрибуты в product_detail, согласно настройкам в ok_okay_cms__feeds__feeds
+
         if (($featureId = $this->feed->settings['color']) && isset($product->features[$featureId])) {
             $result['g:color']['data'] = $this->xmlFeedHelper->escape($product->features[$featureId]['values_string']);
             unset($product->features[$featureId]);


### PR DESCRIPTION
### Что PR делает?

В Okay\Modules\OkayCMS\Feeds\Core\Presets\Adapters\GoogleMerchantAdapter.php добавил код, который перебирает свойства товара и добавляет их в GoogleMerchant фид как g:product_detail

### Зачем PR нужен?

В "Админке - Товарные фиды - Отдельный фид - Настройки свойств" есть настройки, которые не работают при выбранном шаблоне GoogleMerchant. С этим кодом эти "Настройки свойств" начинают работать.
Проверять так: открывать текст фида и искать "g:product_detail" -- должно быть по несколько штук у товара и содержать данные о свойствах.

### Связанные issue(s)/PR(s)

Сообщите нам, если это связано с issue(s)/PR(s) (см. https://github.blog/2013-05-14-closing-issues-via-pull-requests/)