### PR TITLE
Fixed the output of the searched phrase in the search field by comments

### DIFF
--- a/backend/Controllers/CommentsAdmin.php
+++ b/backend/Controllers/CommentsAdmin.php
@@ -45,15 +45,11 @@ class CommentsAdmin extends IndexAdmin
         }
 
         if ($status = $backendCommentsHelper->matchStatus($filter)) {
-            $this->design->assign('type', $status);
-        }
-
-        if (isset($filter['type'])) {
-            $this->design->assign('type', $filter['type']);
+            $this->design->assign('status', $status);
         }
 
         if (isset($filter['keyword'])) {
-            $this->design->assign('type', $filter['keyword']);
+            $this->design->assign('keyword', $filter['keyword']);
         }
 
         $this->design->assign('pages_count',    ceil($commentsCount/$filter['limit']));


### PR DESCRIPTION
### Что PR делает?

Неправильно в Smarty передавалась переменная, ошибка именования была.

### Зачем PR нужен?

В админ. панели на странице Обратная связь - Комментарии теперь искомая фраза корректно отражается в поле поиска