### PR TITLE
fix end slash in category on search page

### DIFF
--- a/Okay/Core/Router.php
+++ b/Okay/Core/Router.php
@@ -480,14 +480,16 @@ class Router {
         }
 
         $result = trim(strip_tags(htmlspecialchars($result)));
-
-        if ($query) {
-            $result = $result.'?'.http_build_query($query);
-        }
         
         // TODO здесь есть скрытая связь с FilterHelper. Это может привести к багам, подумать над тем, чтобы решить это
         if (is_object($route) && method_exists($route, 'hasSlashAtEnd') && $route->hasSlashAtEnd()) {
-            return ExtenderFacade::execute(__METHOD__, rtrim($result, '/').'/', func_get_args());
+            $result = rtrim($result, '/') . '/';
+            if ($query) {
+                $result = $result . '?' . http_build_query($query);
+            }
+            return ExtenderFacade::execute(__METHOD__, $result, func_get_args());
+        } elseif ($query) {
+            $result = $result . '?' . http_build_query($query);
         }
 
         return ExtenderFacade::execute(__METHOD__, $result, func_get_args());


### PR DESCRIPTION
### Что PR делает?

Виправив побудову урла, в якому присутні GET параметри.

### Зачем PR нужен?

На сторінці пошука, при включеному завершаючому слеші для категорій, якщо перейти на категорію, категорія відкривалася по урлу https://demookay.com/catalog/divany?keyword=дивани/ . Тепер урл будується правильно https://demookay.com/catalog/divany/?keyword=дивани
