### PR TITLE
Fixed a bug when the end of the URL part before the slash coincided w…

### DIFF
--- a/Okay/Core/Routes/AbstractRoute.php
+++ b/Okay/Core/Routes/AbstractRoute.php
@@ -132,7 +132,10 @@ abstract class AbstractRoute
     private function removeLangPrefix($uri)
     {
         $langLink = $this->languages->getLangLink($this->languages->getLangId());
-        return str_replace($langLink, '', $uri);
+        if (!empty($langLink)) {
+            return mb_substr($uri, mb_strlen($langLink));
+        }
+        return $uri;
     }
 
     abstract public function hasSlashAtEnd();


### PR DESCRIPTION
### Что PR делает?

В файле Okay/Core/Routes/AbstractRoute.php были сделаны правки по правильному формированию url

### Зачем PR нужен?

При режиме ЧПУ у категорий no_prefix_and_path неправильно формировались url у категорий если окончание фразы перед слеш совпадало с языковым суффиксом если он присутствовал.