### PR TITLE
Syntax error in passing variables to the implode method in the file i…

### DIFF
--- a/backend/design/html/import.tpl
+++ b/backend/design/html/import.tpl
@@ -32,11 +32,11 @@
                     {elseif $message_error == 'required_fields'}
                         {$btr->import_required|escape}
                     {elseif $message_error == 'duplicated_columns'}
-                        {$btr->import_duplicated|escape}: {implode($duplicated_columns, ", ")}
+                        {$btr->import_duplicated|escape}: {implode(", ", $duplicated_columns)}
                     {elseif $message_error == 'duplicated_columns_pairs'}
                         {$btr->import_duplicated_pairs}:<BR>
                         {foreach $duplicated_columns_pairs as $pair}
-                            {implode($pair, ", ")}
+                            {implode(", ", $pair)}
                             {if !$pair@last}<BR>{/if}
                         {/foreach}
                     {else}


### PR DESCRIPTION
…mport.tpl

### Что PR делает?
Обнаружена и исправлена синтаксическая ошибка, перепутаны местами входные переменные в метод

### Зачем PR нужен?
Команда implode срабатывает без ошибок