### PR TITLE
fix_versions_compare_in_admin_module_list

### DIFF
--- a/backend/Controllers/ModulesAdmin.php
+++ b/backend/Controllers/ModulesAdmin.php
@@ -99,6 +99,7 @@ class ModulesAdmin extends IndexAdmin
                 $module->preview = $preview;
             }
             $module->params = $moduleCore->getModuleParams($module->vendor, $module->module_name);
+            $module->module_versions_compare = version_compare($module->params->getVersion(), $module->version); //1 - версия модуля в файлах выше, чем в базе. 0 - одинаковые. -1 - в файлах ниже, чем в базе.
         }
 
         $this->design->assign('modules', $modulesList);

--- a/backend/design/html/module_list.tpl
+++ b/backend/design/html/module_list.tpl
@@ -90,14 +90,12 @@
                 {/if}
                 {/if}
 
-                {if !empty($module->params->getVersion()) && $module->params->getVersion() != $module->version}
-                    {if $module->params->getVersion() > $module->version}{else}
+                {if isset($module->module_versions_compare) && $module->module_versions_compare < 0}
                     <div class="mt-q">
                         <span class="text_attention font_12 text_600">
                             {$btr->module_downgrade_warning} {$module->params->getVersion()}
                         </span>
                     </div>
-                    {/if}
                 {/if}
 
                 {if $module->params->getDaysToExpire() >= 0}
@@ -184,12 +182,10 @@
             <div class="okay_list_boding okay_list_module_version hidden-md-down">
                 <div class="text_700">{$module->version|escape}</div>
 
-                {if !empty($module->params->getVersion()) && $module->params->getVersion() != $module->version}
-                    {if $module->params->getVersion() > $module->version}
+                {if isset($module->module_versions_compare) && $module->module_versions_compare > 0}
                         {if $module->params->isLicensed()}
                         <button type="button" class="fn_update_module btn btn-warning btn--update mt-q hint-top-middle-t-info-s-small-mobile hint-anim" data-hint="{$btr->module_need_update} {$module->params->getVersion()}">{include 'svg_icon.tpl' svgId='refresh_icon'} {$module->params->getVersion()}</button>
                         {/if}
-                    {/if}
                 {/if}
 
                 {if !empty($module->params->getOkayVersion()) && $module->params->getOkayVersion() != $config->version}


### PR DESCRIPTION
### Что PR делает?
исправляет ошибку сравнения версий модуля (файлы и база) в админке в списке модулей. Без этого фикса Окай считал, что версия модуля 1.1.10 Ниже чем версия модуля 1.1.9, выводил сообщение о понижении версии и не отображал кнопку обновления.
С фиксом Окай корректно сравнивает версии модуля, корректно выводит сообщение о понижении версии модуля, корректно выводит кнопку для обновления модуля при повышении версии.

