### PR TITLE
Fixed a bug when the array of shipping methods is empty

### DIFF
--- a/Okay/Modules/OkayCMS/DeliveryFields/Backend/design/html/order_delivery_fields.tpl
+++ b/Okay/Modules/OkayCMS/DeliveryFields/Backend/design/html/order_delivery_fields.tpl
@@ -1,6 +1,6 @@
 {foreach $deliveryFields as $field}
     <div class="mb-1 fn_delivery_field{foreach $field->deliveries as $deliveryId} fn_delivery_field_{$deliveryId}{/foreach}"
-        {if !in_array($order->delivery_id, $field->deliveries)}style="display: none"{/if}
+        {if !empty($field->deliveries) && !in_array($order->delivery_id, $field->deliveries)}style="display: none"{/if}
     >
         <div class="heading_label">
             {$field->name|escape}
@@ -14,13 +14,13 @@
                class="form-control"
                type="text"
                value="{$field->value|escape}"
-               {if !in_array($order->delivery_id, $field->deliveries)}disabled{/if}
+               {if !empty($field->deliveries) && !in_array($order->delivery_id, $field->deliveries)}disabled{/if}
         />
         {if $field->value_id}
             <input name="delivery_fields_values_ids[{$field->id}]"
                    value="{$field->value_id|escape}"
                    type="hidden"
-                   {if !in_array($order->delivery_id, $field->deliveries)}disabled{/if}
+                   {if !empty($field->deliveries) && !in_array($order->delivery_id, $field->deliveries)}disabled{/if}
             />
         {/if}
     </div>


### PR DESCRIPTION
### Что PR делает?

Исправляет ошибки при определенных состояниях в блоке интегрирующимся в админку в карточку заказа

### Зачем PR нужен?

При интеграции в заказ блока из модуля DeliveryFields когда $field->deliveries оказывается пустым то в Smarty метод in_array выдает ошибку если скрипт выполняется на PHP 8.0. Добавлена доппроверка.
