### PR TITLE
Fix redirect for main language and remove prefix from url

### DIFF
--- a/Okay/Core/Router.php
+++ b/Okay/Core/Router.php
@@ -271,7 +271,7 @@ class Router {
         $mainLanguage = self::$languages->getMainLanguage();
         $pattern = '/' . $mainLanguage->label . '(\/.*)?';
         $router->all($pattern, function() use ($mainLanguage) {
-            $uri = preg_replace('~/?'.$mainLanguage->label.'/?~', '', Request::getRequestUri());
+            $uri = preg_replace('~^/?'.$mainLanguage->label.'/?~', '', Request::getRequestUri());
             Response::redirectTo(Request::getRootUrl() . '/' . $uri, 301);
         });
         


### PR DESCRIPTION
### Что PR делает?

Мелкий фикс редиректа, когда в url присутствует основной язык

### Зачем PR нужен?

Ожидаем попасть из-за понятной(стандартной) логики редиректа с основного языка сайта с префиксом /ua/some-ua-link с 301 редиректом на без префикса /some-ua-link, но попадаем на /some-link со статусом 404, т.к. редирект происходит c удалением всех символов главного языка в url в любом месте
