### PR TITLE
Fixed the issue where the mock variantId parameters were overriding digits URL

### DIFF
--- a/Okay/Core/Routes/Strategies/Product/NoPrefixAndCategoryStrategy.php
+++ b/Okay/Core/Routes/Strategies/Product/NoPrefixAndCategoryStrategy.php
@@ -30,7 +30,7 @@ class NoPrefixAndCategoryStrategy extends AbstractRouteStrategy
     // Сообщаем что данная стратегия может использовать sql для формирования урла
     protected $isUsesSqlToGenerate = true;
 
-    private $mockRouteParams = ['{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => '(\d*)'], []];
+    private $mockRouteParams = ['{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => ''], []];
 
     public function __construct()
     {

--- a/Okay/Core/Routes/Strategies/Product/NoPrefixAndPathStrategy.php
+++ b/Okay/Core/Routes/Strategies/Product/NoPrefixAndPathStrategy.php
@@ -41,7 +41,7 @@ class NoPrefixAndPathStrategy extends AbstractRouteStrategy
     // Сообщаем что данная стратегия может использовать sql для формирования урла
     protected $isUsesSqlToGenerate = true;
 
-    private $mockRouteParams = ['{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => '(\d*)'], []];
+    private $mockRouteParams = ['{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => ''], []];
 
     public function __construct()
     {

--- a/Okay/Core/Routes/Strategies/Product/NoPrefixStrategy.php
+++ b/Okay/Core/Routes/Strategies/Product/NoPrefixStrategy.php
@@ -15,7 +15,7 @@ class NoPrefixStrategy extends AbstractRouteStrategy
     /** @var ProductsEntity */
     private $productsEntity;
     
-    private $mockRouteParams = ['{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => '(\d*)'], []];
+    private $mockRouteParams = ['{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => ''], []];
 
     public function __construct()
     {

--- a/Okay/Core/Routes/Strategies/Product/PrefixAndPathStrategy.php
+++ b/Okay/Core/Routes/Strategies/Product/PrefixAndPathStrategy.php
@@ -141,7 +141,7 @@ class PrefixAndPathStrategy extends AbstractRouteStrategy
 
     private function getMockRouteParams($prefix) : array
     {
-        return [$prefix.'/{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => '(\d*)'], []];
+        return [$prefix.'/{$url}/?{$variantId}', ['{$url}' => '', '{$variantId}' => ''], []];
     }
 
     private function matchProductUrlFromUri($url, $categoryPathUrl)


### PR DESCRIPTION
### Что PR делает?

Проблемы с роутингом товаров в разных стратегиях когда категории и товар содержат только цифры

### Зачем PR нужен?

Исправляет ошибку когда variantId параметр по дефолту перехватывал другие цифровые роуты