### PR TITLE
Fix CartController namespace: update FrontTemplateConfig reference, and remove unused imports

### DIFF
--- a/Okay/Controllers/CartController.php
+++ b/Okay/Controllers/CartController.php
@@ -5,9 +5,7 @@ namespace Okay\Controllers;
 
 
 use Okay\Core\Design;
-use Okay\Core\SmartyPlugins\Plugins\CheckoutPaymentForm;
-use Okay\Core\FrontTemplateConfig;
-use Okay\Entities\PaymentsEntity;
+use Okay\Core\TemplateConfig\FrontTemplateConfig;
 use Okay\Entities\ProductsEntity;
 use Okay\Helpers\CartHelper;
 use Okay\Helpers\CouponHelper;


### PR DESCRIPTION
### Что PR делает?

Изменяет/удаляет namespaces в CartController

### Зачем PR нужен?

Исправлено: лишние или неправильные namespaces
