### PR TITLE
Add new options for product description filling in Google Merchant feed

### DIFF
--- a/Okay/Modules/OkayCMS/Feeds/Backend/Core/Presets/Adapters/BackendGoogleMerchantAdapter.php
+++ b/Okay/Modules/OkayCMS/Feeds/Backend/Core/Presets/Adapters/BackendGoogleMerchantAdapter.php
@@ -36,7 +36,9 @@ class BackendGoogleMerchantAdapter extends AbstractBackendPresetAdapter
         $settings = [
             'upload_only_products_in_stock' => $postSettings['upload_only_products_in_stock'] ?? 0,
             'use_full_description' => $postSettings['use_full_description'] ?? 0,
+            'use_full_description_if_not_exist_annotation' => $postSettings['use_full_description_if_not_exist_annotation'] ?? 0,
             'description_in_html' => $postSettings['description_in_html'] ?? 0,
+            'replace_description_by_name_if_empty' => $postSettings['replace_description_by_name_if_empty'] ?? 0,
             'no_export_without_price' => $postSettings['no_export_without_price'] ?? 0,
             'adult' => $postSettings['adult'] ?? 0,
             'use_variant_name_like_size' => $postSettings['use_variant_name_like_size'] ?? 0,

--- a/Okay/Modules/OkayCMS/Feeds/Backend/design/html/presets/google_merchant/settings.tpl
+++ b/Okay/Modules/OkayCMS/Feeds/Backend/design/html/presets/google_merchant/settings.tpl
@@ -142,6 +142,18 @@
                 <div class="activity_of_switch_item">
                     <div class="okay_switch clearfix">
                         <label class="switch_label">
+                            <span>{$btr->okay_cms__feeds__feed__settings__google_merchant__full_description_if_not_exist_annotation|escape}</span>
+                        </label>
+                        <label class="switch switch-default">
+                            <input class="switch-input" name="settings[use_full_description_if_not_exist_annotation]" value='1' type="checkbox" {if $feed->settings['use_full_description_if_not_exist_annotation']}checked=""{/if}/>
+                            <span class="switch-label"></span>
+                            <span class="switch-handle"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="activity_of_switch_item">
+                    <div class="okay_switch clearfix">
+                        <label class="switch_label">
                            <span>{$btr->okay_cms__feeds__feed__settings__google_merchant__use_full_description|escape}</span>
                         </label>
                         <label class="switch switch-default">
@@ -161,6 +173,18 @@
                         </label>
                         <label class="switch switch-default">
                             <input class="switch-input" name="settings[description_in_html]" value='1' type="checkbox" {if $feed->settings['description_in_html']}checked=""{/if}/>
+                            <span class="switch-label"></span>
+                            <span class="switch-handle"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="activity_of_switch_item">
+                    <div class="okay_switch clearfix">
+                        <label class="switch_label">
+                            <span>{$btr->okay_cms__feeds__feed__settings__google_merchant__replace_description_by_name_if_empty|escape}</span>
+                        </label>
+                        <label class="switch switch-default">
+                            <input class="switch-input" name="settings[replace_description_by_name_if_empty]" value='1' type="checkbox" {if $feed->settings['replace_description_by_name_if_empty']}checked=""{/if}/>
                             <span class="switch-label"></span>
                             <span class="switch-handle"></span>
                         </label>

--- a/Okay/Modules/OkayCMS/Feeds/Backend/lang/en.php
+++ b/Okay/Modules/OkayCMS/Feeds/Backend/lang/en.php
@@ -94,6 +94,8 @@ $lang['okay_cms__feeds__feed__settings__google_merchant__color_notify'] = "Selec
 $lang['okay_cms__feeds__feed__settings__google_merchant__gtin'] = "Code GTIN (gtin)";
 $lang['okay_cms__feeds__feed__settings__google_merchant__gender'] = "Gender (gender)";
 $lang['okay_cms__feeds__feed__settings__google_merchant__material'] = "Material (material)";
+$lang['okay_cms__feeds__feed__settings__google_merchant__full_description_if_not_exist_annotation'] = "Send the full product description to the feed only if there is no short description";
+$lang['okay_cms__feeds__feed__settings__google_merchant__replace_description_by_name_if_empty'] = "If the description is empty, replace it with the product name";
 
 // Настройки Rozetka
 $lang['okay_cms__feeds__feed__settings__rozetka__upload_without_images'] = "Upload products without images";

--- a/Okay/Modules/OkayCMS/Feeds/Backend/lang/ru.php
+++ b/Okay/Modules/OkayCMS/Feeds/Backend/lang/ru.php
@@ -94,6 +94,8 @@ $lang['okay_cms__feeds__feed__settings__google_merchant__color_notify'] = "Вы�
 $lang['okay_cms__feeds__feed__settings__google_merchant__gtin'] = "Код GTIN (gtin)";
 $lang['okay_cms__feeds__feed__settings__google_merchant__gender'] = "Пол (gender)";
 $lang['okay_cms__feeds__feed__settings__google_merchant__material'] = "Материал (material)";
+$lang['okay_cms__feeds__feed__settings__google_merchant__full_description_if_not_exist_annotation'] = "Передавать в фид полное описание товара, только если нет краткого";
+$lang['okay_cms__feeds__feed__settings__google_merchant__replace_description_by_name_if_empty'] = "Если описание пустое заменять его названием товара";
 
 // Настройки Rozetka
 $lang['okay_cms__feeds__feed__settings__rozetka__upload_without_images'] = "Выгружать товары без изображений";

--- a/Okay/Modules/OkayCMS/Feeds/Backend/lang/ua.php
+++ b/Okay/Modules/OkayCMS/Feeds/Backend/lang/ua.php
@@ -94,6 +94,8 @@ $lang['okay_cms__feeds__feed__settings__google_merchant__color_notify'] = "Ви�
 $lang['okay_cms__feeds__feed__settings__google_merchant__gtin'] = "Код GTIN (gtin)";
 $lang['okay_cms__feeds__feed__settings__google_merchant__gender'] = "Пол (gender)";
 $lang['okay_cms__feeds__feed__settings__google_merchant__material'] = "Матеріал (material)";
+$lang['okay_cms__feeds__feed__settings__google_merchant__full_description_if_not_exist_annotation'] = "Передавати у фід повний опис товару, тільки якщо немає короткого";
+$lang['okay_cms__feeds__feed__settings__google_merchant__replace_description_by_name_if_empty'] = "Якщо опис порожній, замінювати його назвою товару";
 
 // Настройки Rozetka
 $lang['okay_cms__feeds__feed__settings__rozetka__upload_without_images'] = "Вивантажувати товари без зображень";

--- a/Okay/Modules/OkayCMS/Feeds/Init/module.json
+++ b/Okay/Modules/OkayCMS/Feeds/Init/module.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "vendor": {
     "email": "info@okay-cms.com",
     "site": "https://okay-cms.com"


### PR DESCRIPTION
### Что PR делает?

Исправлена ошибка в модуле Feeds / Google Merchant, при которой передавался пустой тег <description> для товаров без описания, добавлены опции заполнения описания.
