### PR TITLE
Fix in OrderAdmin Novaposhta order details not saving

### DIFF
--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Backend/design/html/order_contact_block.tpl
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Backend/design/html/order_contact_block.tpl
@@ -63,8 +63,8 @@
             <label for="novaposhta_redelivery">{$btr->order_np_redelivery}</label>
         </div>
     </div>
-    {if empty($novaposhta_delivery_data->city_id)}
-        <div class="mb-1 alert alert--error">
+    {if $order->id && empty($novaposhta_delivery_data->city_id)}
+        <div class="mb-1 alert alert--error fn_np_error_city_id">
             <div class="heading_label alert__content">
                 {$btr->np_error_city_id|escape}
             </div>
@@ -159,6 +159,7 @@
             $('input[name=novaposhta_city_name]').val(suggestion.city);
             $('input[name=novaposhta_area_name]').val(suggestion.area);
             $('input[name=novaposhta_region_name]').val(suggestion.region);
+            $('.fn_np_error_city_id').hide();
             if (suggestion.streets_availability) {
                 setStreetAutocomplete(suggestion.ref);
             } else {
@@ -203,6 +204,7 @@
         onSelect: function(suggestion) {
             $('input[name="novaposhta_warehouse_id"]').val(''); //  очищаем выбранное отделение другого города
             $('input[name="novaposhta_city_id"]').val(suggestion.data.ref);
+            $('.fn_np_error_city_id').hide();
             showWarehouses(suggestion.data.ref);
         },
         formatResult: function(suggestion, currentValue) {

--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Backend/design/html/order_contact_block.tpl
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Backend/design/html/order_contact_block.tpl
@@ -14,7 +14,7 @@
     >
         <div class="mb-1">
             <div class="heading_label">{$btr->order_np_city}</div>
-            <input type="text" name="novaposhta_city" class="fn_newpost_city_name form-control" autocomplete="off" value="{$novaposhta_delivery_data->city_name|escape}"{if !$isDoorDelivery} disabled{/if}>
+            <input type="text" name="novaposhta_city" class="fn_newpost_city_name_door form-control" autocomplete="off" value="{$novaposhta_delivery_data->city_name|escape}"{if !$isDoorDelivery} disabled{/if}>
         </div>
         <div class="mb-1">
             <div class="heading_label">{$btr->order_np_street}</div>
@@ -45,7 +45,7 @@
         
         <div class="mb-1">
             <div class="heading_label">{$btr->order_np_city}</div>
-            <input type="text" class="fn_newpost_city_name form-control" autocomplete="off" value="{$novaposhta_delivery_data->city_id|newpost_city}"{if $isDoorDelivery} disabled{/if}>
+            <input type="text" class="fn_newpost_city_name_warehouse form-control" autocomplete="off" value="{$novaposhta_delivery_data->city_id|newpost_city}"{if $isDoorDelivery} disabled{/if}>
         </div>
         <div class="mb-1">
             <div class="heading_label">{$btr->order_np_warehouse}
@@ -150,17 +150,19 @@
     
     // Автокомплит адреса из справочника Новой Почты
     let streetAutocomplete = false;
-    $( ".fn_newpost_city_name" ).devbridgeAutocomplete({
+    $( ".fn_newpost_city_name_door" ).devbridgeAutocomplete({
         serviceUrl: okay.router['OkayCMS_NovaposhtaCost_find_city_for_door'],
-        minChars:1,
+        minChars: 2,
         noCache: false,
+        preventBadQueries: false,
         onSelect: function(suggestion) {
             $('input[name="novaposhta_city_id"]').val(suggestion.ref).trigger('change');
             $('input[name=novaposhta_city_name]').val(suggestion.city);
             $('input[name=novaposhta_area_name]').val(suggestion.area);
             $('input[name=novaposhta_region_name]').val(suggestion.region);
             $('.fn_np_error_city_id').hide();
-            if (suggestion.streets_availability) {
+            // if (suggestion.streets_availability) { Новая Почта перестала присылать корректный параметр у некоторых городов
+            if (true) {
                 setStreetAutocomplete(suggestion.ref);
             } else {
                 if(streetAutocomplete) {
@@ -180,8 +182,9 @@
     {
         $(".fn_newpost_street").devbridgeAutocomplete({
             serviceUrl: okay.router['OkayCMS_NovaposhtaCost_find_street'] + "?city_ref=" + cityRef,
-            minChars:1,
+            minChars:2,
             noCache: false,
+            preventBadQueries: false,
             onSearchStart: function(params) {
                 streetAutocomplete = true;
             },
@@ -196,7 +199,7 @@
         });
     }
     
-    $( ".fn_newpost_city_name" ).devbridgeAutocomplete( {
+    $( ".fn_newpost_city_name_warehouse" ).devbridgeAutocomplete( {
         serviceUrl: okay.router['OkayCMS_NovaposhtaCost_find_city'],
         minChars: 1,
         maxHeight: 320,

--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Extenders/BackendExtender.php
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Extenders/BackendExtender.php
@@ -78,26 +78,27 @@ class BackendExtender implements ExtensionInterface
                 'novaposhta_delivery_data',
                 $this->deliveryDataHelper->getFullDeliveryData((int)$order->id)
             );
+        }
 
-            // Визначаємо які варіанти доставки ведуть до двері або до складу
-            $deliveriesEntity = $this->entityFactory->get(DeliveriesEntity::class);
-            $doorsDeliveries = [];
-            $warehousesDeliveries = [];
-            foreach ($deliveriesEntity->find() as $delivery) {
-                if ($delivery->module_id == $moduleId) {
-                    $deliverySettings = unserialize($delivery->settings);
-                    if ($deliverySettings['service_type'] == 'DoorsDoors'
-                        || $deliverySettings['service_type'] == 'WarehouseDoors') {
-                        $doorsDeliveries[] = $delivery->id;
-                    } else {
-                        $warehousesDeliveries[] = $delivery->id;
-                    }
+        // Визначаємо які варіанти доставки ведуть до двері або до складу
+        $deliveriesEntity = $this->entityFactory->get(DeliveriesEntity::class);
+        $doorsDeliveries = [];
+        $warehousesDeliveries = [];
+        foreach ($deliveriesEntity->find() as $delivery) {
+            if ($delivery->module_id == $moduleId) {
+                $deliverySettings = unserialize($delivery->settings);
+                if ($deliverySettings['service_type'] == 'DoorsDoors'
+                    || $deliverySettings['service_type'] == 'WarehouseDoors') {
+                    $doorsDeliveries[] = $delivery->id;
+                } else {
+                    $warehousesDeliveries[] = $delivery->id;
                 }
             }
-
-            $this->design->assign('doorsDeliveries', $doorsDeliveries);
-            $this->design->assign('warehousesDeliveries', $warehousesDeliveries);
         }
+
+        $this->design->assign('doorsDeliveries', $doorsDeliveries);
+        $this->design->assign('warehousesDeliveries', $warehousesDeliveries);
+        
     }
     
     public function updateDeliveryDataProcedure($order)

--- a/Okay/Modules/OkayCMS/NovaposhtaCost/design/js/np.js
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/design/js/np.js
@@ -105,8 +105,9 @@ $( ".fn_delivery_novaposhta input.city_novaposhta_for_door" ).devbridgeAutocompl
         if (true) {
             $(".fn_delivery_novaposhta input.fn_street").devbridgeAutocomplete({
                 serviceUrl: okay.router['OkayCMS_NovaposhtaCost_find_street'] + "?city_ref=" + suggestion.ref,
-                minChars:1,
+                minChars:2,
                 noCache: false,
+                preventBadQueries: false,
                 onSearchStart: function(params) {
                     streetAutocomplete = true;
                 },


### PR DESCRIPTION
### Что PR делает?

В OrderAdmin добавлять в `$design` данные для Новой почты для нового заказа (`$order->id` там не используется, похоже не там поставили закрывающую фигурную скобку). Сообщение об ошибке "не выбран город" не показывать при создании заказа, сразу скрывать при выборе города в существующем заказе.

### Зачем PR нужен?

При создании нового заказа и выборе доставки "Новая почта" или "Курьерская доставка по городу" название этого способа доставки не отображалось в выпадающем списке (оставалось предыдущее значение, изначально - "Не выбрана"). При сохранении нового заказа с доставкой курьером, детали доставки (город, улица, дом, квартира) не сохранялись, только если сохранить новый заказ, ввести их, и снова сохранить.

### Связанные issue(s)/PR(s)

Issue не создавались, с другими PR не связано