### PR TITLE
Allow adapters.resize.image_quality in config.local.php

### DIFF
--- a/Okay/Core/Adapters/adapters.php
+++ b/Okay/Core/Adapters/adapters.php
@@ -20,6 +20,7 @@ return [
                     new PR('adapters.resize.watermark'),
                     new PR('adapters.resize.watermark_offset_x'),
                     new PR('adapters.resize.watermark_offset_y'),
+                    new PR('adapters.resize.image_quality'),
                 ]
             ],
         ]


### PR DESCRIPTION
### Що PR робить?

Дозволити встановлювати `adapters.resize.image_quality` у `config.local.php`, аналогічно налаштуванням watermark, для передачі до `Okay\Core\Adapters\Resize\AdapterManager::configure(..., $imageQuality = 80)` (далі - `Resize\AdapterManager`) та далі до `Okay\Core\Adapters\Resize\AbstractResize::__construct($imageQuality = 80, ...)`

### Навіщо PR потрібний?

Користувачі просили, щоб можна було змінювати якість ресайзу зі стандартних 80%, які надто псують якість, не даючи виправданого зменшення ваги. У [коментарі в коді](https://github.com/OkayCMS/OkayCMS/blob/8e1e0075a2da642c5d793e64920975e0b545ae76/Okay/Core/Adapters/Resize/AbstractResize.php#L11) заявлено, що цей параметр "береться з налаштувань", проте пошук по кодовій базі показує, що це не було реалізовано, і фактично завжди використовується 80%, якщо тільки не викликати `Resize\AdapterManager::configure()` якимсь модулем чи правкою ядра ще до виклику `Resize\AdapterManager::createAdapter()`.

### Пов'язані issue(s)/PR(s)

Немає