### PR TITLE
The code in the Banners module has been corrected to ensure that the …

### DIFF
--- a/Okay/Modules/OkayCMS/Banners/DTO/BannerSettingsDTO.php
+++ b/Okay/Modules/OkayCMS/Banners/DTO/BannerSettingsDTO.php
@@ -116,8 +116,8 @@ class BannerSettingsDTO implements \JsonSerializable
 
     public function fromArray(array $array)
     {
-        $this->setAsSlider((bool)($array['asSlider'] ?? true));
-        $this->setAutoplay((bool)($array['autoplay'] ?? true));
+        $this->setAsSlider((bool)($array['asSlider'] ?? false));
+        $this->setAutoplay((bool)($array['autoplay'] ?? false));
         $this->setLoop((bool)($array['loop'] ?? false));
         $this->setNav((bool)($array['nav'] ?? false));
         $this->setDots((bool)($array['dots'] ?? false));


### PR DESCRIPTION
…asSlider and autoplay settings are saved correctly

### Что PR делает?

Логика сохранения настроек checkbox в модуле Banners в админке работает корректно

### Зачем PR нужен?

Не сохранялось состояние двух переключателей (checkbox) в контроллере Okay/Modules/OkayCMS/Banners/Backend/Controllers/BannerAdmin.php. Из-за специфики передачи через POST выключенных элементов checkbox по умолчанию при сохранении указывалось активированное значение. И поэтому нельзя было деактивировать две настройки: asSlider, autoplay. Исправлено, по умолчанию устанавливаются выключенные состояние если не приходят данные о этих элементах через POST.
