### PR TITLE
Fix ERR_HTTP2_PROTOCOL_ERROR on checkout with 150+ cart items

### DIFF
--- a/Okay/Controllers/CartController.php
+++ b/Okay/Controllers/CartController.php
@@ -52,9 +52,11 @@ class CartController extends AbstractController
 
         // Если нам запостили amounts, обновляем их
         if ($amounts = $request->post('amounts')) {
+            $cart->beginBatchUpdate();
             foreach ($amounts as $variantId => $amount) {
                 $cart->updateItem($variantId, $amount);
             }
+            $cart->endBatchUpdate();
         }
         
         $this->setMetadataHelper($cartMetadataHelper);

--- a/Okay/Core/Cart.php
+++ b/Okay/Core/Cart.php
@@ -164,6 +164,26 @@ class Cart
         }
     }
 
+    private $deferCookieSave = false;
+
+    /**
+     * Defer setcookie() calls until endBatchUpdate() is called.
+     * Use around loops that call updateItem()/addItem()/deleteItem()
+     * to avoid emitting one Set-Cookie header per iteration.
+     */
+    public function beginBatchUpdate()
+    {
+        $this->deferCookieSave = true;
+    }
+
+    public function endBatchUpdate()
+    {
+        $this->deferCookieSave = false;
+        if (isset($_SESSION['shopping_cart'])) {
+            $this->saveShoppingCart($_SESSION['shopping_cart'] ?? []);
+        }
+    }
+
     /**
      * We save the data of the selected products in a cookie
      *
@@ -171,6 +191,10 @@ class Cart
      */
     public function saveShoppingCart(array $items)
     {
+        if ($this->deferCookieSave) {
+            return;
+        }
+
         if (!empty($items)) {
             $_COOKIE['shopping_cart'] = json_encode($items);
             setcookie('shopping_cart', $_COOKIE['shopping_cart'], time() + 30 * 24 * 3600, '/');   //  на месяц

--- a/Okay/Core/Response.php
+++ b/Okay/Core/Response.php
@@ -101,9 +101,12 @@ class Response
         if (!in_array($responseCode, [301, 302, 303, 307, 308])) {
             throw new \Exception("$responseCode is not a valid redirect response code.");
         }
-        
-        $headerContent = 'Location: ' . $resource;
-        header($headerContent, false, $responseCode);
+
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        header('Location: ' . $resource, true, $responseCode);
         exit;
     }
     

--- a/index.php
+++ b/index.php
@@ -13,6 +13,8 @@ use Psr\Log\LoggerInterface;
 
 ini_set('display_errors', 'off');
 
+ob_start();
+
 require_once('vendor/autoload.php');
 
 if (!empty($_SERVER['HTTP_USER_AGENT'])) {


### PR DESCRIPTION
### What does PR do?

`Cart::saveShoppingCart()` calls `setcookie()` inside `updateItem()`, which is called once per cart item in the amounts-update loop during checkout. With 150 items, this produces **150 identical** `Set-Cookie:
  shopping_cart=...` headers (~3 KB each = **~450 KB of response headers**).

  **Fix:** add `beginBatchUpdate()`/`endBatchUpdate()` to `Cart` that defer `setcookie()` calls until the batch is done. The cookie is now set exactly **once** instead of N times.

  Also: clean output buffers in `Response::redirectTo()` before sending the `Location` header, and add `ob_start()` in `index.php` to support this cleanup.

  ### Changes

  | File | Change |
  |------|--------|
  | `Okay/Core/Cart.php` | Add `beginBatchUpdate()`/`endBatchUpdate()` to defer `setcookie()` until batch is done |
  | `Okay/Controllers/CartController.php` | Wrap amounts-update loop with batch mode |
  | `Okay/Core/Response.php` | Clean output buffers before redirect, use `replace=true` for Location header |
  | `index.php` | Add `ob_start()` so buffer cleanup in `redirectTo()` has a buffer to work with |

  ### Why is PR needed?

  When a customer adds **150+ items** to the cart and submits the checkout form, the browser shows `ERR_HTTP2_PROTOCOL_ERROR` and the order page never loads — even though the order is created in the database.

  ### Root cause

  Each `updateItem()` call triggers `setcookie()` with the full cart as URL-encoded JSON (~3 KB per cookie with 150 items). The checkout POST updates all amounts in a loop (line 54-58 of `CartController`), so with 150
  items the response contains **150 duplicate `Set-Cookie` headers** totaling ~450 KB.

  This exceeds:
  - **HTTP/2** HPACK header compression buffer limits
  - **Go's** default `MaxResponseHeaderBytes` (300 KB), used by Traefik, Caddy, and other Go-based reverse proxies
  - **Browser** internal header size limits

  ### How to reproduce

  1. Add 120+ different products to the cart
  2. Fill in the checkout form and submit
  3. Browser shows `ERR_HTTP2_PROTOCOL_ERROR`
  4. With curl: `curl: (56) Too large response headers: 308673 > 307200`
  5. The order IS created in the database, but the redirect to the order page fails