### PR TITLE
Fix CSV import column mapping when file has UTF-8 BOM

### DIFF
--- a/Okay/Core/Import.php
+++ b/Okay/Core/Import.php
@@ -74,14 +74,31 @@ class Import
     public function initColumns()
     {
         $f = fopen($this->importFilesDir.$this->import_file, 'r');
-        $this->columns = fgetcsv($f, null, $this->columnDelimiter);
+        $columns = fgetcsv($f, null, $this->columnDelimiter);
         fclose($f);
+        $this->columns = is_array($columns) ? $this->normalizeCsvColumns($columns) : [];
+    }
+
+    /**
+     * Excel and other tools often save CSV as UTF-8 with BOM (utf-8-sig).
+     * BOM on the first header cell breaks column name matching (e.g. Category).
+     */
+    private function normalizeCsvColumnName($name)
+    {
+        $name = preg_replace('/^\xEF\xBB\xBF/', '', (string)$name);
+
+        return trim($name);
+    }
+
+    private function normalizeCsvColumns(array $columns)
+    {
+        return array_map([$this, 'normalizeCsvColumnName'], $columns);
     }
 
     // Возвращает внутренние название колонки по названию колонки в файле
     private function internalColumnName($name)
     {
-        $name = trim($name);
+        $name = $this->normalizeCsvColumnName($name);
         $name = str_replace('/', '', $name);
         $name = str_replace('\/', '', $name);
         foreach($this->columnsNames as $i=>$names) {
@@ -105,7 +122,7 @@ class Import
      */
     public function setColumns($columns)
     {
-        $this->columns = $columns;
+        $this->columns = is_array($columns) ? $this->normalizeCsvColumns($columns) : [];
     }
 
     /**


### PR DESCRIPTION
## Problem

CSV files exported from Excel (and many other tools) use UTF-8 with BOM (`utf-8-sig`).
The byte order mark is prepended to the **first header cell**, so e.g. `Category` becomes
`\xEF\xBB\xBFCategory`.

`Okay\Core\Import::initColumns()` did not strip the BOM. As a result,
`internalColumnName()` failed to map the first column to internal fields such as `category`.
Products imported without categories (and any other field in the first column).

## Solution

Normalize header names when reading and setting columns:
- strip UTF-8 BOM (`\xEF\xBB\xBF`)
- trim whitespace

Applied in `initColumns()`, `setColumns()`, and `internalColumnName()`.

## How to reproduce

1. Create `import.csv` with UTF-8 BOM and `Category` as the first column.
2. Upload via Backend → Import.
3. First column is not auto-mapped to category.

## Notes

- Does not change delimiter or row parsing logic.
- Safe for files without BOM (preg_replace is a no-op).
- Branch based on tag `4.5.2` (latest release at time of fix).
