### PR TITLE
Increase ok_images.filename to 1024 for CSV import URLs

### DIFF
--- a/1DB_changes/update_4.5.3.sql
+++ b/1DB_changes/update_4.5.3.sql
@@ -1,0 +1,6 @@
+-- Remote image URLs in CSV import exceeded varchar(255) and were truncated silently.
+ALTER TABLE `ok_images`
+    MODIFY `filename` VARCHAR(1024) NOT NULL DEFAULT '';
+
+ALTER TABLE `ok_spec_img`
+    MODIFY `filename` VARCHAR(1024) NOT NULL DEFAULT '';

--- a/Okay/Core/Image.php
+++ b/Okay/Core/Image.php
@@ -14,6 +14,9 @@ class Image
     
     private $allowedExtensions = ['png', 'gif', 'jpg', 'jpeg', 'ico', 'svg', 'webp'];
 
+    /** Must match ok_images.filename / ok_spec_img.filename column length (see update_4.5.3.sql). */
+    private const FILENAME_MAX_LENGTH = 1024;
+
     private $rootDir;
     
     /**
@@ -478,6 +481,14 @@ class Image
         $res = preg_replace("/[^a-zA-Z0-9.\-_]+/ui", '', $res);
         $res = strtolower($res);
         return ExtenderFacade::execute(__METHOD__, $res, func_get_args());
+    }
+
+    /**
+     * Max length for values stored in ok_images.filename (local names or remote URLs).
+     */
+    public function getFilenameMaxLength()
+    {
+        return self::FILENAME_MAX_LENGTH;
     }
 
     /**

--- a/backend/Helpers/BackendImportHelper.php
+++ b/backend/Helpers/BackendImportHelper.php
@@ -437,44 +437,80 @@ class BackendImportHelper
         /** @var ImagesEntity $imagesEntity */
         $imagesEntity = $this->entityFactory->get(ImagesEntity::class);
         $imagesIds = [];
+        $maxFilenameLength = $this->imageCore->getFilenameMaxLength();
+
         if (!empty($itemImages)) {
             // Изображений может быть несколько, через запятую
             $images = explode(',', $itemImages);
             foreach ($images as $image) {
                 $image = trim($image);
-                if (!empty($image)) {
-                    // Имя файла
-                    $imageFilename = pathinfo($image, PATHINFO_BASENAME);
+                if ($image === '') {
+                    continue;
+                }
 
-                    if (preg_match("~^https?://~", $image)) {
-                        $imageFilename = $this->imageCore->correctFilename($imageFilename);
-                        $image = rawurlencode($image);
-                    }
+                $storedFilename = $image;
+                $basename = pathinfo($image, PATHINFO_BASENAME);
+                $legacyEncodedUrl = null;
 
-                    // Добавляем изображение только если такого еще нет в этом товаре
-                    $select = $this->queryFactory->newSelect();
-                    $result = $select->cols(['id', 'filename'])
-                        ->from('__images')
-                        ->where('product_id=:product_id')
-                        ->where('(filename=:image_filename OR filename=:image)')
-                        ->limit(1)
-                        ->bindValue('product_id', $productId)
-                        ->bindValue('image_filename', $imageFilename)
-                        ->bindValue('image', $image)
-                        ->result();
+                if (preg_match('~^https?://~i', $image)) {
+                    // Keep original URL (do not rawurlencode the whole string — it grows and breaks matching).
+                    $legacyEncodedUrl = rawurlencode($image);
+                    $basename = $this->imageCore->correctFilename($basename);
+                }
 
-                    if (empty($result->filename)) {
-                        $newImage = new \stdClass();
-                        $newImage->product_id = $productId;
-                        $newImage->filename = $image;
-                        $imagesIds[] = $imagesEntity->add($newImage);
-                    } else {
-                        $imagesIds[] = $result->id;
-                    }
+                if (strlen($storedFilename) > $maxFilenameLength) {
+                    $this->logImportImageSkip(
+                        $productId,
+                        $image,
+                        'filename exceeds ok_images.filename limit (' . $maxFilenameLength . ')'
+                    );
+                    continue;
+                }
+
+                // Добавляем изображение только если такого еще нет в этом товаре
+                $select = $this->queryFactory->newSelect();
+                $select->cols(['id', 'filename'])
+                    ->from('__images')
+                    ->where('product_id=:product_id')
+                    ->bindValue('product_id', $productId);
+
+                if ($legacyEncodedUrl !== null) {
+                    $select->where('(filename=:stored OR filename=:basename OR filename=:legacy_encoded)')
+                        ->bindValue('stored', $storedFilename)
+                        ->bindValue('basename', $basename)
+                        ->bindValue('legacy_encoded', $legacyEncodedUrl);
+                } else {
+                    $select->where('(filename=:stored OR filename=:basename)')
+                        ->bindValue('stored', $storedFilename)
+                        ->bindValue('basename', $basename);
+                }
+
+                $result = $select->limit(1)->result();
+
+                if (empty($result->filename)) {
+                    $newImage = new \stdClass();
+                    $newImage->product_id = $productId;
+                    $newImage->filename = $storedFilename;
+                    $imagesIds[] = $imagesEntity->add($newImage);
+                } else {
+                    $imagesIds[] = $result->id;
                 }
             }
         }
         return ExtenderFacade::execute(__METHOD__, $imagesIds, func_get_args());
+    }
+
+    /**
+     * Log skipped import images (check PHP error_log / server logs).
+     */
+    private function logImportImageSkip($productId, $imageSource, $reason)
+    {
+        error_log(sprintf(
+            'OkayCMS import: skip image for product #%d: %s — %s',
+            (int)$productId,
+            $reason,
+            mb_substr((string)$imageSource, 0, 300)
+        ));
     }
     
     private function isFeature($importColumnName)


### PR DESCRIPTION
## Problem

`ok_images.filename` was `varchar(255)`.

On CSV import, `BackendImportHelper::importImages()` stored `rawurlencode($url)` in that column. Long supplier CDN URLs exceeded 255 characters → MySQL **silently truncated** the value → broken gallery thumbnails.

## Solution

1. **Migration** `1DB_changes/update_4.5.3.sql`: `ok_images.filename` and `ok_spec_img.filename` → `VARCHAR(1024)`.
2. **Import**: store the **original** `http(s)` URL (do not `rawurlencode` the entire string — it inflates length and breaks matching).
3. **Validation**: if length exceeds 1024, skip the image and write to `error_log` (no silent truncation).
4. **`Image::getFilenameMaxLength()`** — documents the column limit for import code.

CSV import stays **fast** (no HTTP downloads per row). Lazy download via `Image::downloadImage()` on first resize is unchanged.

Duplicate detection still matches legacy rows that store plain or `rawurlencode` URLs.

## Upgrade

Run database update **4.5.3** (admin updater or `1DB_changes/update_4.5.3.sql`).

Catalogs already imported with truncated URLs need image rows fixed (re-import `Images` column or a one-off repair script).

## Testing

1. Apply migration; confirm `SHOW COLUMNS FROM ok_images LIKE 'filename'` → `varchar(1024)`.
2. Import CSV with a remote image URL ~300 characters in `Images`.
3. Before: `filename` truncated to 255, broken thumb. After: full URL stored, thumb loads on first view (lazy download).
4. Import URL > 1024 chars → skipped, message in PHP `error_log`.