### PR TITLE
We pass to the module not the short but the full name of the street, …

### DIFF
--- a/Okay/Modules/OkayCMS/NovaposhtaCost/Backend/design/html/order_contact_block.tpl
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/Backend/design/html/order_contact_block.tpl
@@ -185,7 +185,7 @@
                 streetAutocomplete = true;
             },
             onSelect: function(suggestion){
-                $('input[name=novaposhta_street_name]').val(suggestion.street);
+                $('input[name=novaposhta_street_name]').val(suggestion.value);
             },
             formatResult: function(suggestion, currentValue) {
                 var reEscape = new RegExp( '(\\' + ['/', '.', '*', '+', '?', '|', '(', ')', '[', ']', '{', '}', '\\'].join( '|\\' ) + ')', 'g' );

--- a/Okay/Modules/OkayCMS/NovaposhtaCost/design/js/np.js
+++ b/Okay/Modules/OkayCMS/NovaposhtaCost/design/js/np.js
@@ -111,7 +111,7 @@ $( ".fn_delivery_novaposhta input.city_novaposhta_for_door" ).devbridgeAutocompl
                     streetAutocomplete = true;
                 },
                 onSelect: function(suggestion){
-                    delivery_block.find('input[name=novaposhta_street_name]').val(suggestion.street);
+                    delivery_block.find('input[name=novaposhta_street_name]').val(suggestion.value);
                 },
                 formatResult: function(suggestion, currentValue) {
                     var reEscape = new RegExp( '(\\' + ['/', '.', '*', '+', '?', '|', '(', ')', '[', ']', '{', '}', '\\'].join( '|\\' ) + ')', 'g' );


### PR DESCRIPTION
…so that, for example, it can be understood whether it is a street or a boulevard

### Что PR делает?
Были исправлена логика в модуле Новая Почта - адресная доставка, теперь передается полное название улицы для сохранения адреса доставки в заказе

### Зачем PR нужен?

Ранее при сохранении у доставки Новая Почта - адресной доставке передавалось чистое короткое название улицы. 
И из-за этого, когда в городе была и улица и бульвар с одинаковым названием, было непонятно какой именно адрес указал клиент в корзине, т.е. в админ-панели админу было непонятно, какой вариант клиент выбрал: улицу или бульвар.
Теперь модуль сохраняет полное название приставка, например ул. или бул.
Это исправлено в корзине. Также исправлено и для админ-панели в карточке заказа.
